### PR TITLE
fix a typo in common.cpp and remove a header file in tpm2_quote

### DIFF
--- a/sapi-tools/common.cpp
+++ b/sapi-tools/common.cpp
@@ -489,7 +489,7 @@ int saveTpmContextToFile(TSS2_SYS_CONTEXT *sysContext, TPM_HANDLE handle, const 
     rval = Tss2_Sys_ContextSave( sysContext, handle, &context);
     if( rval == TPM_RC_SUCCESS &&
         saveDataToFile(fileName, (UINT8 *)&context, sizeof(TPMS_CONTEXT)) )
-        rval == TPM_RC_FAILURE;
+        rval = TPM_RC_FAILURE;
 
     if( rval != TPM_RC_SUCCESS )
     {

--- a/sapi-tools/tpm2_quote.cpp
+++ b/sapi-tools/tpm2_quote.cpp
@@ -56,7 +56,10 @@
 #include <limits.h>
 #include <ctype.h>
 #include <getopt.h>
+
+#ifdef _WIN32
 #include <arpa/inet.h>
+#endif
 
 #include <tpm2sapi/tpm20.h>
 #include <tpm2tcti/tpmsockets.h>


### PR DESCRIPTION
fix a typo about function saveTpmContextToFile(... ) in file common.cpp,
the included header file arpa/inet.h in tpm2_quote.cpp is no need on _WIN32.