### PR TITLE
Remove depenedency on the resourcemgr header from the TPM2.0-TSS repo.

### DIFF
--- a/sapi-tools/Makefile.am
+++ b/sapi-tools/Makefile.am
@@ -61,8 +61,7 @@ TPMTOOLS_COMMON_SRC = \
 
 INCLUDE_DIRS = -I$(srcdir)/../tss/sysapi/include -I$(srcdir) \
     -I$(srcdir)/../tss/tcti/tpmsockets -I$(srcdir)/../tss/common \
-    -I$(srcdir)/../tss/test/common/sample -I$(srcdir)/../tss/resourcemgr \
-    -I$(srcdir)/../tss/test/tpmclient
+    -I$(srcdir)/../tss/test/common/sample -I$(srcdir)/../tss/test/tpmclient
 
 AM_CFLAGS   = -DSAPI_CLIENT $(INCLUDE_DIRS)
 AM_CXXFLAGS = -DSAPI_CLIENT $(INCLUDE_DIRS)

--- a/sapi-tools/common.cpp
+++ b/sapi-tools/common.cpp
@@ -62,7 +62,6 @@
 
 #include <tpm2sapi/tpm20.h>
 #include "sample.h"
-#include "resourcemgr.h"
 #include "tpmclient.h"
 #include <tpm2sapi/tss2_sysapi_util.h>
 #include <tpm2tcti/tpmsockets.h>


### PR DESCRIPTION
This header was included in the common.cpp file but as far as I can
tell, none of the tools code acutally uses anything from it.

This resolves #14

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>