### PR TITLE
common: Do not include tpm2sapi/tss2_sapi_util.h

### DIFF
--- a/sapi-tools/common.cpp
+++ b/sapi-tools/common.cpp
@@ -62,7 +62,6 @@
 
 #include <tpm2sapi/tpm20.h>
 #include "sample.h"
-#include <tpm2sapi/tss2_sysapi_util.h>
 #include <tpm2tcti/tpmsockets.h>
 #include "syscontext.h"
 #include "debug.h"


### PR DESCRIPTION
This file no longer pulls in the TCTI_MAGIC / TCTI_VERSION. It is also
not a standard tss2 header so it will go away soon. These are values
come from a TCTI implementation and so we get them from the respective
TCTI headers instead now.

This resolves #19

Signed-off-by: Philip Tricca <flihp@twobit.us>