### PR TITLE
Sapi header cleanup

### DIFF
--- a/sapi-tools/CopySizedBuffer.c
+++ b/sapi-tools/CopySizedBuffer.c
@@ -25,7 +25,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //**********************************************************************;
 
-#include <tpm2sapi/tpm20.h>   
+#include <tss2/tpm20.h>
 
 UINT16 CopySizedByteBuffer( TPM2B *dest, TPM2B *src )
 {

--- a/sapi-tools/DecryptEncrypt.c
+++ b/sapi-tools/DecryptEncrypt.c
@@ -25,7 +25,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //**********************************************************************;
 
-#include <tpm2sapi/tpm20.h>   
+#include <tss2/tpm20.h>
 #include "sample.h"
 #include <string.h>
 

--- a/sapi-tools/Entity.c
+++ b/sapi-tools/Entity.c
@@ -25,9 +25,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //**********************************************************************;
 
-#include <tpm2sapi/tpm20.h>   
+#include <tss2/tpm20.h>
 #include "sample.h"
-#include <tpm2sapi/tss2_sysapi_util.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/sapi-tools/LoadExternalHMACKey.c
+++ b/sapi-tools/LoadExternalHMACKey.c
@@ -25,8 +25,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //**********************************************************************;
 
-#include <tpm2sapi/tpm20.h>   
-#include <tpm2sapi/tss2_sysapi_util.h>
+#include <tss2/tpm20.h>
 #include "sample.h"
 
 

--- a/sapi-tools/Makefile.am
+++ b/sapi-tools/Makefile.am
@@ -87,7 +87,7 @@ noinst_PROGRAMS = tpm2_listpcrs \
 		  tpm2_sign \
 		  tpm2_unseal \
 		  tpm2_verifysignature
-LDADD = -ltpm2sapi -ltpm2tctisock
+LDADD = -ltss2 -ltctisocket
 tpm2_listpcrs_SOURCES = $(TPMTOOLS_COMMON_SRC) tpm2_listpcrs.cpp
 tpm2_quote_SOURCES = $(TPMTOOLS_COMMON_SRC) tpm2_quote.cpp
 tpm2_takeownership_SOURCES = $(TPMTOOLS_COMMON_SRC) tpm2_takeownership.cpp

--- a/sapi-tools/Makefile.am
+++ b/sapi-tools/Makefile.am
@@ -35,6 +35,7 @@ COMMON_SRC = \
     syscontext.c
 SAMPLE_SRC = \
     CatSizedByteBuffer.c \
+    changeEndian.c \
     CopySizedBuffer.c \
     DecryptEncrypt.c \
     Entity.c \

--- a/sapi-tools/SessionHmac.c
+++ b/sapi-tools/SessionHmac.c
@@ -25,11 +25,10 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //**********************************************************************;
 
-#include <tpm2sapi/tpm20.h>   
+#include <tss2/tpm20.h>
 #include "sample.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include <tpm2sapi/tss2_sysapi_util.h>
 
 //
 // This function calculates the session HMAC and updates session state.

--- a/sapi-tools/StartAuthSession.c
+++ b/sapi-tools/StartAuthSession.c
@@ -25,9 +25,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //**********************************************************************;
 
-#include <tpm2sapi/tpm20.h>   
+#include <tss2/tpm20.h>
 #include "sample.h"
-#include <tpm2sapi/tss2_sysapi_util.h>
 #include <stdlib.h>
 
 #define SESSIONS_ARRAY_COUNT MAX_NUM_SESSIONS+1

--- a/sapi-tools/TpmCalcPHash.c
+++ b/sapi-tools/TpmCalcPHash.c
@@ -25,11 +25,11 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //**********************************************************************;
 
-#include <tpm2sapi/tpm20.h>   
+#include <tss2/tpm20.h>
+#include "changeEndian.h"
 #include "sample.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include <tpm2sapi/tss2_sysapi_util.h>
 
 //
 // This function is a helper function used to calculate cpHash and rpHash.

--- a/sapi-tools/TpmHandleToName.c
+++ b/sapi-tools/TpmHandleToName.c
@@ -25,9 +25,9 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //**********************************************************************;
 
-#include <tpm2sapi/tpm20.h>   
+#include <tss2/tpm20.h>
+#include "changeEndian.h"
 #include "sample.h"
-#include <tpm2sapi/tss2_sysapi_util.h>
 
 //
 //

--- a/sapi-tools/TpmHash.c
+++ b/sapi-tools/TpmHash.c
@@ -25,9 +25,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //**********************************************************************;
 
-#include <tpm2sapi/tpm20.h>   
+#include <tss2/tpm20.h>
 #include "sample.h"
-#include <tpm2sapi/tss2_sysapi_util.h>
 
 //
 // This function does a hash on a string of data.

--- a/sapi-tools/TpmHmac.c
+++ b/sapi-tools/TpmHmac.c
@@ -25,9 +25,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //**********************************************************************;
 
-#include <tpm2sapi/tpm20.h>   
+#include <tss2/tpm20.h>
 #include "sample.h"
-#include <tpm2sapi/tss2_sysapi_util.h>
 
 //
 // This function does an HMAC on a null-terminated list of input buffers.

--- a/sapi-tools/changeEndian.c
+++ b/sapi-tools/changeEndian.c
@@ -27,14 +27,28 @@
 
 #include <tss2/tpm20.h>
 
-void CatSizedByteBuffer( TPM2B *dest, TPM2B *src )
+UINT64 ChangeEndianQword( UINT64 p )
 {
-    int i;
-
-    if( dest != 0  && src != 0 )
-    {
-        for( i = 0; i < src->size; i++ )
-            dest->buffer[ dest->size + i] = src->buffer[i];
-        dest->size += src->size;
-    }
+    return( ((const UINT64)(((p)& 0xFF) << 56))    | \
+          ((const UINT64)(((p)& 0xFF00) << 40))   | \
+          ((const UINT64)(((p)& 0xFF0000) << 24)) | \
+          ((const UINT64)(((p)& 0xFF000000) << 8)) | \
+          ((const UINT64)(((p)& 0xFF00000000) >> 8)) | \
+          ((const UINT64)(((p)& 0xFF0000000000) >> 24)) | \
+          ((const UINT64)(((p)& 0xFF000000000000) >> 40)) | \
+          ((const UINT64)(((p)& 0xFF00000000000000) >> 56)) );
 }
+
+UINT32 ChangeEndianDword( UINT32 p )
+{
+    return( ((const UINT32)(((p)& 0xFF) << 24))    | \
+          ((const UINT32)(((p)& 0xFF00) << 8))   | \
+          ((const UINT32)(((p)& 0xFF0000) >> 8)) | \
+          ((const UINT32)(((p)& 0xFF000000) >> 24)));
+}
+
+UINT16 ChangeEndianWord( UINT16 p )
+{
+    return( ((const UINT16)(((p)& 0xFF) << 8)) | ((const UINT16)(((p)& 0xFF00) >> 8)));
+}
+

--- a/sapi-tools/changeEndian.h
+++ b/sapi-tools/changeEndian.h
@@ -25,16 +25,48 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //**********************************************************************;
 
-#include <tss2/tpm20.h>
+#ifndef ENDIANCONV_H
+#define ENDIANCONV_H
 
-void CatSizedByteBuffer( TPM2B *dest, TPM2B *src )
-{
-    int i;
+#ifndef TSS2_API_VERSION_1_1_1_1
+#error Version mismatch among TSS2 header files !
+#endif  /* TSS2_API_VERSION_1_1_1_1 */
 
-    if( dest != 0  && src != 0 )
-    {
-        for( i = 0; i < src->size; i++ )
-            dest->buffer[ dest->size + i] = src->buffer[i];
-        dest->size += src->size;
-    }
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+//
+// Comment out following line for big endian CPUs.
+//
+#define LITTLE_ENDIAN_CPU
+
+#ifdef LITTLE_ENDIAN_CPU
+
+UINT64 ChangeEndianQword( UINT64 p );
+UINT32 ChangeEndianDword( UINT32 p );
+UINT16 ChangeEndianWord( UINT16 p );
+
+// CPU is little endian, so bytes need to be swapped.
+#define CHANGE_ENDIAN_WORD(p) ( ChangeEndianWord (p) )
+
+#define CHANGE_ENDIAN_DWORD(p) ( ChangeEndianDword(p) )
+
+#define CHANGE_ENDIAN_QWORD(p) ( ChangeEndianQword(p) )
+#else
+ // If CPU is big-endian, no need to do endianness swapping.
+
+#define CHANGE_ENDIAN_WORD(p)  p
+
+#define CHANGE_ENDIAN_DWORD(p) p
+
+#define CHANGE_ENDIAN_QWORD(p) p
+#endif
+
+#ifdef __cplusplus
 }
+#endif
+
+#endif

--- a/sapi-tools/common.c
+++ b/sapi-tools/common.c
@@ -62,7 +62,7 @@
 
 #include <tss2/tpm20.h>
 #include "sample.h"
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "syscontext.h"
 #include "debug.h"
 #include "common.h"
@@ -221,7 +221,7 @@ TSS2_RC InitTctiResMgrContext( char *rmInterfaceConfig, TSS2_TCTI_CONTEXT **tcti
 
     TSS2_RC rval;
 
-    rval = InitSocketsTcti(NULL, &size, rmInterfaceConfig, TCTI_MAGIC, TCTI_VERSION, resMgrInterfaceName, 0 );
+    rval = InitSocketTcti(NULL, &size, rmInterfaceConfig, TCTI_MAGIC, TCTI_VERSION, resMgrInterfaceName, 0 );
     if( rval != TSS2_RC_SUCCESS )
         return rval;
 
@@ -229,7 +229,7 @@ TSS2_RC InitTctiResMgrContext( char *rmInterfaceConfig, TSS2_TCTI_CONTEXT **tcti
 
     if( *tctiContext )
     {
-        rval = InitSocketsTcti(*tctiContext, &size, rmInterfaceConfig, TCTI_MAGIC, TCTI_VERSION, resMgrInterfaceName, 0 );
+        rval = InitSocketTcti(*tctiContext, &size, rmInterfaceConfig, TCTI_MAGIC, TCTI_VERSION, resMgrInterfaceName, 0 );
     }
     else
     {
@@ -240,7 +240,7 @@ TSS2_RC InitTctiResMgrContext( char *rmInterfaceConfig, TSS2_TCTI_CONTEXT **tcti
 
 TSS2_RC TeardownTctiResMgrContext( char *interfaceConfig, TSS2_TCTI_CONTEXT *tctiContext, char *name )
 {
-    return TeardownSocketsTcti(tctiContext, interfaceConfig, name);
+    return TeardownSocketTcti(tctiContext, interfaceConfig, name);
 }
 
 void Cleanup()

--- a/sapi-tools/debug.c
+++ b/sapi-tools/debug.c
@@ -28,7 +28,7 @@
 #include <stdio.h>
 #include <stdlib.h>   // Needed for _wtoi
 
-#include <tpm2sapi/tpm20.h>
+#include <tss2/tpm20.h>
 #include "debug.h"
 
 UINT8 rmDebugPrefix = 0;

--- a/sapi-tools/kdfa.c
+++ b/sapi-tools/kdfa.c
@@ -25,11 +25,11 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //**********************************************************************;
 
-#include <tpm2sapi/tpm20.h>
+#include <tss2/tpm20.h>
 #include "sample.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include <tpm2sapi/tss2_sysapi_util.h>
+#include "changeEndian.h"
 
 //
 //

--- a/sapi-tools/sample.h
+++ b/sapi-tools/sample.h
@@ -33,7 +33,7 @@ extern "C" {
 #endif
 
 
-#include <tpm2sapi/tss2_tpm2_types.h>
+#include <tss2/tss2_tpm2_types.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "syscontext.h"

--- a/sapi-tools/syscontext.c
+++ b/sapi-tools/syscontext.c
@@ -25,10 +25,9 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //**********************************************************************;
 
-#include <tpm2sapi/tpm20.h>   
+#include <tss2/tpm20.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <tpm2sapi/tss2_sysapi_util.h>
 
 
 // Allocates space for and initializes system

--- a/sapi-tools/syscontext.h
+++ b/sapi-tools/syscontext.h
@@ -28,8 +28,7 @@
 #ifndef SYS_CONTEXT_H
 #define SYS_CONTEXT_H
 
-#include "tpm2sapi/tpm20.h"
-#include "tpm2sapi/tss2_sysapi_util.h"
+#include "tss2/tpm20.h"
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/sapi-tools/tpm2_activatecredential.cpp
+++ b/sapi-tools/tpm2_activatecredential.cpp
@@ -59,7 +59,7 @@
 #include <getopt.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 #include "sample.h"
 

--- a/sapi-tools/tpm2_activatecredential.cpp
+++ b/sapi-tools/tpm2_activatecredential.cpp
@@ -58,8 +58,8 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 #include "sample.h"
 

--- a/sapi-tools/tpm2_akparse.cpp
+++ b/sapi-tools/tpm2_akparse.cpp
@@ -57,8 +57,8 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 
 char akDataFile[PATH_MAX];

--- a/sapi-tools/tpm2_akparse.cpp
+++ b/sapi-tools/tpm2_akparse.cpp
@@ -58,7 +58,7 @@
 #include <getopt.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 
 char akDataFile[PATH_MAX];

--- a/sapi-tools/tpm2_certify.cpp
+++ b/sapi-tools/tpm2_certify.cpp
@@ -59,7 +59,7 @@
 #include <getopt.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_certify.cpp
+++ b/sapi-tools/tpm2_certify.cpp
@@ -58,8 +58,8 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_create.cpp
+++ b/sapi-tools/tpm2_create.cpp
@@ -58,7 +58,7 @@
 #include <getopt.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 
 TPMS_AUTH_COMMAND sessionData;

--- a/sapi-tools/tpm2_create.cpp
+++ b/sapi-tools/tpm2_create.cpp
@@ -57,8 +57,8 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 
 TPMS_AUTH_COMMAND sessionData;

--- a/sapi-tools/tpm2_createprimary.cpp
+++ b/sapi-tools/tpm2_createprimary.cpp
@@ -58,7 +58,7 @@
 #include <getopt.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_createprimary.cpp
+++ b/sapi-tools/tpm2_createprimary.cpp
@@ -57,8 +57,8 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_encryptdecrypt.cpp
+++ b/sapi-tools/tpm2_encryptdecrypt.cpp
@@ -59,7 +59,7 @@
 #include <getopt.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_encryptdecrypt.cpp
+++ b/sapi-tools/tpm2_encryptdecrypt.cpp
@@ -58,8 +58,8 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_evictcontrol.cpp
+++ b/sapi-tools/tpm2_evictcontrol.cpp
@@ -58,7 +58,7 @@
 #include <getopt.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_evictcontrol.cpp
+++ b/sapi-tools/tpm2_evictcontrol.cpp
@@ -57,8 +57,8 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_getpubak.cpp
+++ b/sapi-tools/tpm2_getpubak.cpp
@@ -57,8 +57,8 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 #include "sample.h"
 

--- a/sapi-tools/tpm2_getpubak.cpp
+++ b/sapi-tools/tpm2_getpubak.cpp
@@ -58,7 +58,7 @@
 #include <getopt.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 #include "sample.h"
 

--- a/sapi-tools/tpm2_getpubek.cpp
+++ b/sapi-tools/tpm2_getpubek.cpp
@@ -58,7 +58,7 @@
 #include <getopt.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_getpubek.cpp
+++ b/sapi-tools/tpm2_getpubek.cpp
@@ -57,8 +57,8 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_getrandom.cpp
+++ b/sapi-tools/tpm2_getrandom.cpp
@@ -58,7 +58,7 @@
 #include <ctype.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_getrandom.cpp
+++ b/sapi-tools/tpm2_getrandom.cpp
@@ -57,8 +57,8 @@
 #include <getopt.h>
 #include <ctype.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_hash.cpp
+++ b/sapi-tools/tpm2_hash.cpp
@@ -58,7 +58,7 @@
 #include <getopt.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_hash.cpp
+++ b/sapi-tools/tpm2_hash.cpp
@@ -57,8 +57,8 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_hmac.cpp
+++ b/sapi-tools/tpm2_hmac.cpp
@@ -58,7 +58,7 @@
 #include <getopt.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 
 TPMS_AUTH_COMMAND sessionData;

--- a/sapi-tools/tpm2_hmac.cpp
+++ b/sapi-tools/tpm2_hmac.cpp
@@ -57,8 +57,8 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 
 TPMS_AUTH_COMMAND sessionData;

--- a/sapi-tools/tpm2_listpcrs.cpp
+++ b/sapi-tools/tpm2_listpcrs.cpp
@@ -58,7 +58,7 @@
 #include <getopt.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 
 #define SET_PCR_SELECT_BIT( pcrSelection, pcr ) \

--- a/sapi-tools/tpm2_listpcrs.cpp
+++ b/sapi-tools/tpm2_listpcrs.cpp
@@ -57,8 +57,8 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 
 #define SET_PCR_SELECT_BIT( pcrSelection, pcr ) \

--- a/sapi-tools/tpm2_load.cpp
+++ b/sapi-tools/tpm2_load.cpp
@@ -58,7 +58,7 @@
 #include <getopt.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 
 TPM_HANDLE handle2048rsa;

--- a/sapi-tools/tpm2_load.cpp
+++ b/sapi-tools/tpm2_load.cpp
@@ -57,8 +57,8 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 
 TPM_HANDLE handle2048rsa;

--- a/sapi-tools/tpm2_loadexternal.cpp
+++ b/sapi-tools/tpm2_loadexternal.cpp
@@ -58,7 +58,7 @@
 #include <getopt.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 
 TPM_HANDLE handle2048rsa;

--- a/sapi-tools/tpm2_loadexternal.cpp
+++ b/sapi-tools/tpm2_loadexternal.cpp
@@ -57,8 +57,8 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 
 TPM_HANDLE handle2048rsa;

--- a/sapi-tools/tpm2_makecredential.cpp
+++ b/sapi-tools/tpm2_makecredential.cpp
@@ -58,7 +58,7 @@
 #include <getopt.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_makecredential.cpp
+++ b/sapi-tools/tpm2_makecredential.cpp
@@ -57,8 +57,8 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_nvdefine.cpp
+++ b/sapi-tools/tpm2_nvdefine.cpp
@@ -58,7 +58,7 @@
 #include <getopt.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_nvdefine.cpp
+++ b/sapi-tools/tpm2_nvdefine.cpp
@@ -57,8 +57,8 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_nvlist.cpp
+++ b/sapi-tools/tpm2_nvlist.cpp
@@ -57,8 +57,9 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
+#include "changeEndian.h"
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_nvlist.cpp
+++ b/sapi-tools/tpm2_nvlist.cpp
@@ -58,7 +58,7 @@
 #include <getopt.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "changeEndian.h"
 #include "common.h"
 

--- a/sapi-tools/tpm2_nvread.cpp
+++ b/sapi-tools/tpm2_nvread.cpp
@@ -58,7 +58,7 @@
 #include <getopt.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_nvread.cpp
+++ b/sapi-tools/tpm2_nvread.cpp
@@ -57,8 +57,8 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_nvrelease.cpp
+++ b/sapi-tools/tpm2_nvrelease.cpp
@@ -58,7 +58,7 @@
 #include <getopt.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_nvrelease.cpp
+++ b/sapi-tools/tpm2_nvrelease.cpp
@@ -57,8 +57,8 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_nvwrite.cpp
+++ b/sapi-tools/tpm2_nvwrite.cpp
@@ -58,7 +58,7 @@
 #include <getopt.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_nvwrite.cpp
+++ b/sapi-tools/tpm2_nvwrite.cpp
@@ -57,8 +57,8 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_quote.cpp
+++ b/sapi-tools/tpm2_quote.cpp
@@ -58,7 +58,7 @@
 #include <getopt.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_quote.cpp
+++ b/sapi-tools/tpm2_quote.cpp
@@ -57,8 +57,8 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_readpublic.cpp
+++ b/sapi-tools/tpm2_readpublic.cpp
@@ -58,7 +58,7 @@
 #include <getopt.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_readpublic.cpp
+++ b/sapi-tools/tpm2_readpublic.cpp
@@ -57,8 +57,8 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_rsadecrypt.cpp
+++ b/sapi-tools/tpm2_rsadecrypt.cpp
@@ -58,7 +58,7 @@
 #include <getopt.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_rsadecrypt.cpp
+++ b/sapi-tools/tpm2_rsadecrypt.cpp
@@ -57,8 +57,8 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_rsaencrypt.cpp
+++ b/sapi-tools/tpm2_rsaencrypt.cpp
@@ -58,7 +58,7 @@
 #include <getopt.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_rsaencrypt.cpp
+++ b/sapi-tools/tpm2_rsaencrypt.cpp
@@ -57,8 +57,8 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_sign.cpp
+++ b/sapi-tools/tpm2_sign.cpp
@@ -58,7 +58,7 @@
 #include <getopt.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_sign.cpp
+++ b/sapi-tools/tpm2_sign.cpp
@@ -57,8 +57,8 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_takeownership.cpp
+++ b/sapi-tools/tpm2_takeownership.cpp
@@ -58,7 +58,7 @@
 #include <getopt.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_takeownership.cpp
+++ b/sapi-tools/tpm2_takeownership.cpp
@@ -57,8 +57,8 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_unseal.cpp
+++ b/sapi-tools/tpm2_unseal.cpp
@@ -57,9 +57,9 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
+#include <tss2/tpm20.h>
 //#include "sample.h"
-#include <tpm2tcti/tpmsockets.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_unseal.cpp
+++ b/sapi-tools/tpm2_unseal.cpp
@@ -59,7 +59,7 @@
 
 #include <tss2/tpm20.h>
 //#include "sample.h"
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_verifysignature.cpp
+++ b/sapi-tools/tpm2_verifysignature.cpp
@@ -58,7 +58,7 @@
 #include <getopt.h>
 
 #include <tss2/tpm20.h>
-#include <tcti/tpmsockets.h>
+#include <tcti/tcti_socket.h>
 #include "common.h"
 
 int debugLevel = 0;

--- a/sapi-tools/tpm2_verifysignature.cpp
+++ b/sapi-tools/tpm2_verifysignature.cpp
@@ -57,8 +57,8 @@
 #include <ctype.h>
 #include <getopt.h>
 
-#include <tpm2sapi/tpm20.h>
-#include <tpm2tcti/tpmsockets.h>
+#include <tss2/tpm20.h>
+#include <tcti/tpmsockets.h>
 #include "common.h"
 
 int debugLevel = 0;


### PR DESCRIPTION
Update tpm2.0-tools to account for latest changes in the TPM2.0-TSS headers. IMHO this is the "right way" to resolve issue #125 in the TPM2.0-TSS project.