### PR TITLE
build: Move libcommon.a to the front of LDADD.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -36,7 +36,7 @@ INCLUDE_DIRS = -I$(srcdir)
 
 AM_CFLAGS   = -DSAPI_CLIENT $(INCLUDE_DIRS)
 AM_CXXFLAGS = -DSAPI_CLIENT $(INCLUDE_DIRS)
-LDADD = -ltss2 -ltctisocket src/libcommon.a
+LDADD = src/libcommon.a -ltss2 -ltctisocket
 
 noinst_LIBRARIES = src/libcommon.a
 sbin_PROGRAMS = src/tpm2_listpcrs \


### PR DESCRIPTION
The order of these libraries is significant when linking 'as-needed'.

This resolves #31

Signed-off-by: Philip Tricca <flihp@twobit.us>