### PR TITLE
build: Detect required TSS2 and TCTI headers.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,4 +6,19 @@ LT_INIT
 AM_INIT_AUTOMAKE([foreign
                   subdir-objects])
 AC_CONFIG_FILES([Makefile])
+AC_CHECK_HEADER([tss2/tpm20.h],
+                [
+                 AC_DEFINE([HAVE_TPM20_H],
+                           [1],
+                           [Define if tpm20.h exists.])
+                 ],
+                [AC_MSG_ERROR([Missing TSS2 headers.])])
+AC_CHECK_HEADER([tcti/tcti_socket.h],
+                [
+                 AC_DEFINE([HAVE_TCTI_SOCKET_H],
+                           [1],
+                           [Define if tcti_socket.h exists.])
+                 ],
+                [AC_MSG_ERROR([Missing TCTI socket header.])],
+                [#include <tss2/tpm20.h>])
 AC_OUTPUT


### PR DESCRIPTION
Resolves #34

Signed-off-by: Philip Tricca <flihp@twobit.us>