### PR TITLE
configure.ac: Allow for the unit tests to be enabled selectively.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 Unreleased
 Added
+* Allow for unit tests to be enabled selectively.
 * tpm2_rc_decode tool: Decode TPM_RC error codes.
 * Android Make file
 * tpm2_listpersistent: list all persistent objects

--- a/Makefile.am
+++ b/Makefile.am
@@ -74,9 +74,11 @@ sbin_PROGRAMS = src/tpm2_listpcrs \
 		  src/tpm2_listpersistent \
 		  src/tpm2_rc_decode
 
+if UNIT
 check_PROGRAMS = \
     test/tpm2-rc-decode_unit \
     test/tpm2-rc-entry_unit
+endif
 
 COMMON_SRC = \
     src/common.c \
@@ -132,6 +134,7 @@ src_tpm2_verifysignature_SOURCES = src/tpm2_verifysignature.cpp
 src_tpm2_listpersistent_SOURCES = src/tpm2_listpersistent.cpp
 src_tpm2_rc_decode_SOURCES = src/rc-decode.c src/tpm2_rc_decode.c
 
+if UNIT
 test_tpm2_rc_decode_unit_CFLAGS  = $(AM_CXXFLAGS) $(CMOCKA_CFLAGS)
 test_tpm2_rc_decode_unit_LDADD   = $(CMOCKA_LIBS)
 test_tpm2_rc_decode_unit_SOURCES = test/tpm2-rc-decode_unit.c
@@ -139,3 +142,4 @@ test_tpm2_rc_decode_unit_SOURCES = test/tpm2-rc-decode_unit.c
 test_tpm2_rc_entry_unit_CFLAGS   = $(AM_CXXFLAGS) $(CMOCKA_CFLAGS)
 test_tpm2_rc_entry_unit_LDADD    = $(CMOCKA_LIBS)
 test_tpm2_rc_entry_unit_SOURCES  = src/rc-decode.c test/tpm2-rc-entry_unit.c
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -10,5 +10,15 @@ PKG_CHECK_MODULES([SAPI],[sapi])
 PKG_CHECK_MODULES([TCTI_SOCK],[tcti-socket])
 PKG_CHECK_MODULES([TCTI_DEV],[tcti-device])
 PKG_CHECK_MODULES([CURL],[libcurl libcrypto])
-PKG_CHECK_MODULES([CMOCKA],[cmocka])
+AC_ARG_ENABLE([unit],
+            [AS_HELP_STRING([--enable-unit],
+                            [build cmocka unit tests (default is no)])],
+            [enable_unit=$enableval],
+            [enable_unit=no])
+AS_IF([test "x$enable_unit" != xno],
+      [PKG_CHECK_MODULES([CMOCKA],
+                         [cmocka],
+                         [AC_DEFINE([HAVE_CMOCKA],
+                                    [1])])])
+AM_CONDITIONAL([UNIT], [test "x$enable_unit" != xno])
 AC_OUTPUT


### PR DESCRIPTION
This makes the dependence on libcmocka optional.

Signed-off-by: Philip Tricca <flihp@twobit.us>