### PR TITLE
common: Remove use of TeardownSocketTcti.

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -235,9 +235,10 @@ TSS2_RC InitTctiResMgrContext( TCTI_SOCKET_CONF *rmInterfaceConfig, TSS2_TCTI_CO
     return rval;
 }
 
-TSS2_RC TeardownTctiResMgrContext( TSS2_TCTI_CONTEXT *tctiContext )
+void TeardownTctiResMgrContext( TSS2_TCTI_CONTEXT *tctiContext )
 {
-    return TeardownSocketTcti(tctiContext);
+    tss2_tcti_finalize (tctiContext);
+    free (tctiContext);
 }
 
 void Cleanup()


### PR DESCRIPTION
This function has been removed from the socket TCTI upstream. All finalization
should be done through the finalize function pointer in the TCTI
structure. tss2_tcti_finalize is the right helper macro for this. We must
deallocate the TCTI context structure ourselves now too. Finally this patch
also removes the return value from the TeardownTctiResMgrContext function.
None of the finalization functions return any data and we were never checking
this value anyways.

Signed-off-by: Philip Tricca <flihp@twobit.us>