### PR TITLE
A series of bug fixes

### DIFF
--- a/src/tpm2_evictcontrol.cpp
+++ b/src/tpm2_evictcontrol.cpp
@@ -136,9 +136,9 @@ void showHelp(const char *name)
             "\t3 (resource manager tables)\n"
         "\n"
         "Example:\n"
-        "%s -A o -H 0x80000000 -S 0x8101002 -P abc123 \n"
-        "%s -A p -H 0x80000000 -S 0x8101002\n\n"// -i <simulator IP>\n\n",DEFAULT_TPM_PORT);
-        "%s -A o -H 0x80000000 -S 0x8101002 -P 123abc -X\n"
+        "%s -A o -H 0x80000000 -S 0x81010002 -P abc123 \n"
+        "%s -A p -H 0x80000000 -S 0x81010002\n\n"// -i <simulator IP>\n\n",DEFAULT_TPM_PORT);
+        "%s -A o -H 0x80000000 -S 0x81010002 -P 123abc -X\n"
         ,name, DEFAULT_RESMGR_TPM_PORT, name, name, name);
 }
 

--- a/src/tpm2_getmanufec.cpp
+++ b/src/tpm2_getmanufec.cpp
@@ -201,8 +201,8 @@ int createEKHandle()
 
     if (strlen(ekPasswd) > 0 && !hexPasswd)
     {
-        sessionData.hmac.t.size = strlen(ekPasswd);
-        memcpy( &sessionData.hmac.t.buffer[0], ekPasswd, sessionData.hmac.t.size );
+        inSensitive.t.sensitive.userAuth.t.size = strlen(ekPasswd);
+        memcpy( &inSensitive.t.sensitive.userAuth.t.buffer[0], ekPasswd, inSensitive.t.sensitive.userAuth.t.size );
     }
     else if (strlen(ekPasswd) > 0 && hexPasswd)
     {

--- a/src/tpm2_getpubak.cpp
+++ b/src/tpm2_getpubak.cpp
@@ -235,15 +235,10 @@ int createAK()
 
     // set the object Auth value
     inSensitive.t.sensitive.userAuth.t.size = 0;
-    if( strlen( akPasswd ) > 0 )
+    if (strlen(akPasswd) > 0 && !hexPasswd)
     {
         inSensitive.t.sensitive.userAuth.t.size = strlen( akPasswd );
         memcpy( &( inSensitive.t.sensitive.userAuth.t.buffer[0] ), &( akPasswd[0] ), inSensitive.t.sensitive.userAuth.t.size );
-    }
-    if (strlen(akPasswd) > 0 && !hexPasswd)
-    {
-        sessionData.hmac.t.size = strlen(akPasswd);
-        memcpy( &sessionData.hmac.t.buffer[0], akPasswd, sessionData.hmac.t.size );
     }
     else if (strlen(akPasswd) > 0 && hexPasswd)
     {

--- a/src/tpm2_getpubek.cpp
+++ b/src/tpm2_getpubek.cpp
@@ -187,8 +187,8 @@ int createEKHandle()
 
     if (strlen(ekPasswd) > 0 && !hexPasswd)
     {
-        sessionData.hmac.t.size = strlen(ekPasswd);
-        memcpy( &sessionData.hmac.t.buffer[0], ekPasswd, sessionData.hmac.t.size );
+        inSensitive.t.sensitive.userAuth.t.size = strlen(ekPasswd);
+        memcpy( &inSensitive.t.sensitive.userAuth.t.buffer[0], ekPasswd, inSensitive.t.sensitive.userAuth.t.size );
     }
     else if (strlen(ekPasswd) > 0 && hexPasswd)
     {

--- a/test/test_tpm2_hmac.sh
+++ b/test/test_tpm2_hmac.sh
@@ -92,7 +92,7 @@ fi
 rm -f $file_hmac_output  
 tpm2_evictcontrol -A o -c $file_hmac_key_ctx -S $handle_hmac_key |tee evict.log
 c1="$?"
-grep "persistentHanlde: "$handle_hmac_key"" evict.log
+grep "persistentHandle: "$handle_hmac_key"" evict.log
 c2="$?"
 
 if [ $c1 != 0 ] || [ $c2 != 0  ];then

--- a/test/test_tpm2_sign.sh
+++ b/test/test_tpm2_sign.sh
@@ -87,7 +87,7 @@ fi
 
 tpm2_evictcontrol -A o -c $file_signing_key_ctx -S $handle_signing_key |tee evict.log
 c1="$?"
-grep "persistentHanlde: "$handle_signing_key"" evict.log
+grep "persistentHandle: "$handle_signing_key"" evict.log
 c2="$?"
 
 if [ $c1 != 0 ] || [ $c2 != 0  ];then


### PR DESCRIPTION
Fixed below issues:

1. some test scripts will check the output of some tools for correction check. Some checks were based on some output with typo, now the typo in the code was fixed, but the test scripts was missed.

2. the commit adding -X option for most tools introduced some password input usage issues, which caused that the handle password might be used for owner or endorse password.

3. tpm2_evictcontrol -h will export samples with bad object handles.