### PR TITLE
tpm2_takeownership: update option -c to use lockout password to clear

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,7 @@ Added
 * Copy 'common' and 'sample' code from the TPM2.0-TSS repo.
 
 Modified
+* tpm2_takeownership: update option -c to use lockout password to clear.
 * tpm2_listpcrs: add options -L and -s, rewrite to increase performance.
 * tpm2_quote: added -L option to support selection of multiple banks.
 * tpm2_quote: add -q option to get qualifying data.

--- a/manual
+++ b/manual
@@ -200,10 +200,11 @@ where:
   -L/--oldLockPasswd <password>    old Lockout authorization (string, optional,
                                    default:NULL).
   -X/--passwdInHex                 passwords given by any options are hex format
+  -c/--clear                       clears the 3 authorizations values.
 
 example:
 Set ownerAuth, endorsementAuth and lockoutAuth to emptyAuth: 
-    tpm2_takeownership -c
+    tpm2_takeownership -c -L old
 Set ownerAuth, endorsementAuth and lockoutAuth to a newAuth: 
     tpm2_takeownership -o new -e new -l new -O old -E old -L old
     tpm2_takeownership -o 2a2b2c -e 2a2b2c -l 2a2b2c -O 1a1b1c -E 1a1b1c -L 1a1b1c -X


### PR DESCRIPTION
On production version platform, the platform auth is usually set by
BIOS and not available to applications. So change to do clearing via
giving LOCKOUT auth/password.