### PR TITLE
.gitignore: Ignore tpm2_listpersistent and tpm2_nvreadlock binaries.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ src/tpm2_rsadecrypt
 src/tpm2_sign
 src/tpm2_hmac
 src/tpm2_nvdefine
+src/tpm2_nvreadlock
 src/tpm2_load
 src/tpm2_readpublic
 src/tpm2_unseal
@@ -46,6 +47,7 @@ src/tpm2_verifysignature
 src/tpm2_createprimary
 src/tpm2_quote
 src/tpm2_listpcrs
+src/tpm2_listpersistent
 src/tpm2_evictcontrol
 src/tpm2_getpubek
 src/tpm2_takeownership
@@ -55,3 +57,4 @@ src/tpm2_rc_decode
 test-driver
 test/tpm2-rc-decode_unit
 test/tpm2-rc-entry_unit
+


### PR DESCRIPTION
Signed-off-by: Philip Tricca <flihp@twobit.us>