### PR TITLE
.gitignore: add missing binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ src/tpm2_takeownership
 src/tpm2_loadexternal
 src/tpm2_getmanufec
 src/tpm2_rc_decode
+src/tpm2_listpersistent
+src/tpm2_nvreadlock
 test-driver
 test/tpm2-rc-decode_unit
 test/tpm2-rc-entry_unit


### PR DESCRIPTION
Binaries:
 * src/tpm2_listpersistent
 * src/tpm2_nvreadlock

Were missing from the .gitignore, add them so they don't
accidentally get committed.

Signed-off-by: William Roberts <william.c.roberts@intel.com>