### PR TITLE
travis: correct wget over http

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ addons:
     - libcurl4-openssl-dev
 
 install: 
-    - wget http://downloads.sourceforge.net/project/ibmswtpm2/ibmtpm532.tar
+    - wget https://downloads.sourceforge.net/project/ibmswtpm2/ibmtpm532.tar
+    - sha256sum ibmtpm532.tar | grep -q abc0b420257917ccb42a9750588565d5e84a2b4e99a6f9f46c3dad1f9912864f
     - mkdir ibmtpm532 && pushd ibmtpm532 && tar xzf ../ibmtpm532.tar && pushd ./src && make
     - ./tpm_server &
     - popd && popd


### PR DESCRIPTION
Use a a protocol that is not susceptable to man-in-the-
middle attacks for downloading a binary to the CI server.

Signed-off-by: William Roberts <william.c.roberts@intel.com>