### PR TITLE
context-util: free context memory after failed initialization c…

### DIFF
--- a/src/context-util.c
+++ b/src/context-util.c
@@ -118,6 +118,7 @@ tcti_socket_init (char const *address,
     rc = InitSocketTcti (tcti_ctx, &size, &conf, 0);
     if (rc != TSS2_RC_SUCCESS) {
         fprintf (stderr, "Failed to initialize tcti context: 0x%x\n", rc);
+        free (tcti_ctx);
         return NULL;
     }
     return tcti_ctx;
@@ -152,6 +153,7 @@ sapi_ctx_init (TSS2_TCTI_CONTEXT *tcti_ctx)
     rc = Tss2_Sys_Initialize (sapi_ctx, size, tcti_ctx, &abi_version);
     if (rc != TSS2_RC_SUCCESS) {
         fprintf (stderr, "Failed to initialize SAPI context: 0x%x\n", rc);
+        free (sapi_ctx);
         return NULL;
     }
     return sapi_ctx;


### PR DESCRIPTION
…alls.

This is a hazard of the model for TCTI and SAPI context initialization.
It's possible for the first call to succeed while the second call fails.
In this case we must free the allocated data before we return an error
indicator (a NULL pointer). Otherwise we leak the memory we allocated
for the context structure.

There are 3 cases where this may happen in the context-util module. One
was already handled properly. This commit fixes up the other two.

Signed-off-by: Philip Tricca <flihp@twobit.us>