### PR TITLE
tests: gitignore addition

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,8 @@
+# Ignore everything
+*
+# But not these files...
+!.gitignore
+!README.md
+!get-capability-tpm-prop-fixed.bin
+!*.sh
+!*.c


### PR DESCRIPTION
Only worry about shell scripts, unit tests, test fixtures,
the readme and the gitignore file itself.  and ignore the
test artifacts that end up in this directory.

Signed-off-by: William Roberts <william.c.roberts@intel.com>