### PR TITLE
tpm2_rc_decode: add man page and convert help

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,7 +44,8 @@ sbin_PROGRAMS = \
     src/tpm2_createprimary \
     src/tpm2_send_command \
     src/tpm2_dump_capability \
-    src/tpm2_startup
+    src/tpm2_startup \
+    src/tpm2_rc_decode
 
 COMMON_SRC = \
     src/context-util.c \
@@ -88,8 +89,7 @@ sbin_PROGRAMS += src/tpm2_listpcrs \
 		  src/tpm2_sign \
 		  src/tpm2_unseal \
 		  src/tpm2_verifysignature \
-		  src/tpm2_listpersistent \
-		  src/tpm2_rc_decode
+		  src/tpm2_listpersistent
 
 COMMON_SRC += \
     src/common.c \
@@ -144,7 +144,8 @@ man8_MANS = \
     man/man8/tpm2_sign.8 \
     man/man8/tpm2_unseal.8 \
     man/man8/tpm2_verifysignature.8 \
-    man/man8/tpm2_listpersistent.8
+    man/man8/tpm2_listpersistent.8 \
+    man/man8/tpm2_rc_decode.8
 
 src_libcommon_a_SOURCES = $(COMMON_SRC)
 if HAVE_TCTI_SOCK
@@ -184,9 +185,11 @@ endif
 src_tpm2_create_SOURCES = src/tpm2_create.c src/main.c
 src_tpm2_createprimary_SOURCES = src/tpm2_createprimary.c src/main.c
 src_tpm2_dump_capability_SOURCES = src/tpm2_dump_capability.c src/main.c
-src_tpm2_rc_decode_SOURCES = src/rc-decode.c src/tpm2_rc_decode.c
 src_tpm2_send_command_SOURCES = src/tpm2_send_command.c src/main.c
 src_tpm2_startup_SOURCES = src/tpm2_startup.c src/main.c
+
+# rc_decode does not use common main, since it does not need a dynamic TCTI.
+src_tpm2_rc_decode_SOURCES = src/rc-decode.c src/tpm2_rc_decode.c
 
 if UNIT
 test_unit_tpm2_rc_decode_unit_CFLAGS  = $(AM_CFLAGS) $(CMOCKA_CFLAGS)

--- a/man/tpm2_rc_decode.8.in
+++ b/man/tpm2_rc_decode.8.in
@@ -1,0 +1,47 @@
+." Copyright (c) 2016, Intel Corporation
+." All rights reserved.
+."
+." Redistribution and use in source and binary forms, with or without
+." modification, are permitted provided that the following conditions are met:
+."
+." 1. Redistributions of source code must retain the above copyright notice,
+." this list of conditions and the following disclaimer.
+."
+." 2. Redistributions in binary form must reproduce the above copyright notice,
+." this list of conditions and the following disclaimer in the documentation
+." and/or other materials provided with the distribution.
+."
+." 3. Neither the name of Intel Corporation nor the names of its contributors
+." may be used to endorse or promote products derived from this software without
+." specific prior written permission.
+."
+." THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+." AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+." IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+." ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+." LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+." CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+." SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+." INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+." CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+." ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+." THE POSSIBILITY OF SUCH DAMAGE.
+.TH tpm2_rc_decode 8 "DECEMBER 2016" Intel "tpm2.0-tools"
+.SH NAME
+tpm2_rc_decode\ - convert error codes from the SAPI and TCTI into human readable errors. Analogous to strerror(3), but for the tpm2 stack.
+.SH SYNOPSIS
+.B tpm2_rc_decode
+.IR error_code
+.PP
+Convert a hex error_code into an error message.
+.SH DESCRIPTION
+.B tpm2_rc_decode
+Convert a hex error_code into an error message.
+.SH EXAMPLES
+.B tpm2_rc_decode
+.PP
+.nf
+.RS
+tpm2_rc_decode 0x100
+.RE
+.fi


### PR DESCRIPTION
Update rc_decode to use:
1. log.h for error messages
2. man pages for help output

Signed-off-by: William Roberts <william.c.roberts@intel.com>