### PR TITLE
.travis.yml: Remove `make install` in favor of PATH manipulation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,7 @@ script:
   - ../configure --enable-unit
   - make -j$(nproc)
   - make -j$(nproc) check
-  - sudo make install
   - popd
   - pushd ./test/system
-  - ./test_all.sh
+  - PATH=$(pwd)/../../build/src:${PATH} ./test_all.sh
   - popd


### PR DESCRIPTION
Installing the tools is a crutch and one that will back fire if we ever
want to automate builds for multiple configurations.

Signed-off-by: Philip Tricca <flihp@twobit.us>

This resolves #179 