### PR TITLE
string-bytes: re-implement string to value routines

### DIFF
--- a/src/string-bytes.h
+++ b/src/string-bytes.h
@@ -1,13 +1,60 @@
 #ifndef STRING_BYTES_H
 #define STRING_BYTES_H
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include <sapi/tpm20.h>
 
-int getSizeUint16(const char *arg, UINT16 *num);
-int getSizeUint16Hex(const char *arg, UINT16 *num);
-int getSizeUint32(const char *arg, UINT32 *num);
-int getSizeUint32Hex(const char *arg, UINT32 *num);
 int str2ByteStructure(const char *inStr, UINT16 *byteLenth, BYTE *byteBuffer);
 int hex2ByteStructure(const char *inStr, UINT16 *byteLenth, BYTE *byteBuffer);
+
+/**
+ * Converts a numerical string into a uint32 value.
+ * @param str
+ *  The numerical string to convert.
+ * @param value
+ *  The value to store the conversion into.
+ * @return
+ *  true on success, false otherwise.
+ */
+bool string_bytes_get_uint32(const char *str, uint32_t *value);
+
+/**
+ * Converts a numerical string into a uint16 value.
+ * @param str
+ *  The numerical string to convert.
+ * @param value
+ *  The value to store the conversion into.
+ * @return
+ *  true on success, false otherwise.
+ */
+bool string_bytes_get_uint16(const char *str, uint16_t *value);
+
+/*
+ * Leave the old interfaces for now and mark as deprecated,
+ * on porting activities fix-up callers of these.
+ */
+#define deprecated __attribute__ ((deprecated))
+static inline int deprecated getSizeUint16(const char *arg, UINT16 *num) {
+
+    return !string_bytes_get_uint16(arg, num);
+}
+
+static inline int deprecated getSizeUint16Hex(const char *arg, UINT16 *num) {
+
+    return !string_bytes_get_uint16(arg, num);
+}
+
+static inline int deprecated getSizeUint32(const char *arg, UINT32 *num) {
+
+    return !string_bytes_get_uint32(arg, num);
+}
+
+static inline int deprecated getSizeUint32Hex(const char *arg, UINT32 *num) {
+
+    return !string_bytes_get_uint32(arg, num);
+}
+#undef deprecated
 
 #endif /* STRING_BYTES_H */

--- a/src/tpm2_createprimary.c
+++ b/src/tpm2_createprimary.c
@@ -44,6 +44,7 @@
 
 #include "main.h"
 #include "options.h"
+#include "string-bytes.h"
 
 TPMS_AUTH_COMMAND sessionData;
 bool hexPasswd = false;


### PR DESCRIPTION
getSizeUintXX and getSizeUintXXHex routines were very similair.
Refactor them to use strtoul(), and allow strtoul to handle the base.
Also, call the 32 bit variant from the 16 and just check for overflow.

Mark the old interfaces as deprecated, since there are a TON of callers and
convert them on later porting/refactoring endeavors.

Signed-off-by: William Roberts <william.c.roberts@intel.com>