### PR TITLE
bootstrap: Replace manual invocation of autotools with autoreconf.

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -1,10 +1,3 @@
 #! /bin/sh
 
-printf "Running libtoolize ...\n"
-libtoolize --install
-printf "Running aclocal ...\n"
-aclocal
-printf "Running autoconf ...\n"
-autoconf
-printf "Running automake ...\n"
-automake --add-missing
+autoreconf --install --sym


### PR DESCRIPTION
This is the preferred method and much more simple than calling each
autotool in succession.

Signed-off-by: Philip Tricca <flihp@twobit.us>