### PR TITLE
configure: use git describe for version number

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,5 @@
-AC_INIT([tpm2.0-tools], [1.1.0])
+AC_INIT([tpm2.0-tools],
+    [m4_esyscmd_s([git describe --tags --always --dirty])])
 AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_CC
 LT_INIT


### PR DESCRIPTION
Remove the hardcoded version number and use git describe. This makes
it impossible to release a version of the tools that does not agree
with the git tag.

Additionally, builds not on a tag will be marked dirty:

$ ./src/tpm2_listpcrs -v
./src/tpm2_listpcrs, version v1.1.0-81-ga5d2946

Once the current HEAD is a tag, it will only read the tag number.

Signed-off-by: William Roberts <william.c.roberts@intel.com>