### PR TITLE
man: Add closing parenthesis in troff conditional for TCTI opts / env.

### DIFF
--- a/man/tcti-environment.troff
+++ b/man/tcti-environment.troff
@@ -12,11 +12,11 @@ In most configurations this will be the TPM but it could be a simulator or
 proxy.
 See '\fBOPTIONS\fR' section for the names of supported TCTIs.
 .TP
-.if (\n[HAVE_TCTI_DEV] \{
+.if (\n[HAVE_TCTI_DEV]) \{
 \fBTPM2TOOLS_DEVICE_FILE\fR
 Specify the TPM device file for use by the device TCTI.
 \}
-.if (\n[HAVE_TCTI_SOCK] \{
+.if (\n[HAVE_TCTI_SOCK]) \{
 .TP
 \fBTPM2TOOLS_SOCKET_ADDRESS\fR
 Specify the domain name or IP address used by the socket TCTI.

--- a/man/tcti-options.troff
+++ b/man/tcti-options.troff
@@ -13,12 +13,12 @@ Supported TCTIs are
 .if (\n[HAVE_TCTI_SOCK]) or \fB\*(lqsocket\*(rq\fR
 \[char46]
 .TP
-.if (\n[HAVE_TCTI_DEV] \{
+.if (\n[HAVE_TCTI_DEV]) \{
 \fB\-d,\ \-\-device-file\fR
 Specify the TPM device file for use by the device TCTI. The default is
 /dev/tpm0.
 \}
-.if (\n[HAVE_TCTI_SOCK] \{
+.if (\n[HAVE_TCTI_SOCK]) \{
 .TP
 \fB\-R,\ \-\-socket-address\fR
 Specify the domain name or IP address used by the socket TCTI. The default


### PR DESCRIPTION
These warnings can be output for the tpm2_create command:
MANPATH=$(pwd)/man man --warnings=all tpm2_create > /dev/null
<standard input>:109: warning: missing `)' (got `\{')
<standard input>:114: warning: missing `)' (got `\{')
<standard input>:137: warning: missing `)' (got `\{')
<standard input>:141: warning: missing `)' (got `\{')

Signed-off-by: Philip Tricca <flihp@twobit.us>