### PR TITLE
Add an example "default" environment file to minimize output binary s…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,15 +34,15 @@ before_script:
 script:
   - mkdir ./build
   - pushd ./build
-  - ../configure --enable-unit
+  - CONFIG_SITE=../lib/default_config.site ../configure --enable-unit
   - make -j$(nproc)
   - make -j$(nproc) check
   - make -j$(nproc) clean
-  - ../configure --enable-unit --without-tcti-socket
+  - CONFIG_SITE=../lib/default_config.site ../configure --enable-unit --without-tcti-socket
   - make -j$(nproc)
   - make -j$(nproc) check
   - make -j$(nproc) clean
-  - ../configure --enable-unit --without-tcti-device
+  - CONFIG_SITE=../lib/default_config.site ../configure --enable-unit --without-tcti-device
   - make -j$(nproc)
   - make -j$(nproc) check
   - popd

--- a/lib/default_config.site
+++ b/lib/default_config.site
@@ -1,0 +1,2 @@
+CFLAGS="-fdata-sections -ffunction-sections"
+LDFLAGS="-Wl,--gc-sections"


### PR DESCRIPTION
…ize.

We're building most of the source into a "utility" library and linking
all tools against it. By default the linker includes everything in the
library, not just the code needed by the executable. Providing these
flags to the compiler and linker reduces the size of the output binaries
by more than a half. Using tpm2_create as an example...

Without this new CONFIG_SITE file:

$ stat -c "%s %n" src/tpm2_create
85080 ./src/tpm2_create

With this new CONFIG_SITE file:

$state -c "%s %n" src/tpm2_create
29680 ./src/tpm2_create

The .travis.yml file is updated to use these flags as well.

Signed-off-by: Philip Tricca <flihp@twobit.us>