### PR TITLE
options: fix memory corruption

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -76,7 +76,6 @@
 }
 
 typedef enum {
-    TCTI_0,
 #ifdef HAVE_TCTI_DEV
     DEVICE_TCTI,
 #endif


### PR DESCRIPTION
Fix:
==28639== Invalid read of size 1
==28639==    at 0x4C31F93: strcmp (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==28639==    by 0x4020CC: tcti_type_from_name (options.c:85)
==28639==    by 0x40260E: get_common_opts (options.c:300)
==28639==    by 0x401A0A: main (main.c:57)
==28639==  Address 0x3 is not stack'd, malloc'd or (recently) free'd

This occurs when searching the tcti_map_table for a match. The
tcti_map_table and the bounding enum N_TCTI was mismtached, as the
enum entry has a 0 value causing all accesses to be off by one.
Since there were no useres of TCTI_0, remove.

Fixes: #222

Signed-off-by: William Roberts <william.c.roberts@intel.com>