### PR TITLE
files: fix BE_CONVERT macro

### DIFF
--- a/lib/files.c
+++ b/lib/files.c
@@ -223,14 +223,14 @@ static bool readx(FILE *f, UINT8 *data, size_t size) {
 #define BE_CONVERT(value, size) \
     do { \
         if (!string_bytes_is_host_big_endian()) { \
-            string_bytes_endian_convert_##size(value); \
+            value = string_bytes_endian_convert_##size(value); \
         } \
     } while (0)
 
 #define FILE_WRITE(size) \
     bool files_write_##size(FILE *out, UINT##size data) { \
         BAIL_ON_NULL("FILE", out); \
-        BE_CONVERT(&data, size); \
+        BE_CONVERT(data, size); \
         return writex(out, (UINT8 *)&data, sizeof(data)); \
     }
 
@@ -240,7 +240,7 @@ static bool readx(FILE *f, UINT8 *data, size_t size) {
 	    BAIL_ON_NULL("data", data); \
         bool res = readx(out, (UINT8 *)data, sizeof(*data)); \
         if (res) { \
-            BE_CONVERT(data, size); \
+            BE_CONVERT(*data, size); \
         } \
         return res; \
     }


### PR DESCRIPTION
When the interface was changed to pass-by-value versus
pointers, BE_MACRO was not updated properly. Correct this
to suppress the warning:

../lib/files.c: In function ‘files_read_16’:
../lib/files.c:251:1: warning: passing argument 1 of ‘string_bytes_endian_convert_16’ makes integer from pointer without a cast [enabled by default]
FILE_READ(16);

Fixes #237

Signed-off-by: William Roberts <william.c.roberts@intel.com>