### PR TITLE
tpm2_getrandom: update help and simplify interface

### DIFF
--- a/man/tpm2_getrandom.8.in
+++ b/man/tpm2_getrandom.8.in
@@ -28,20 +28,17 @@
 .\" THE POSSIBILITY OF SUCH DAMAGE.
 .TH tpm2_getrandom 8 "DECEMBER 2016" Intel "tpm2.0-tools"
 .SH NAME
-tpm2_getrandom\ - returns the next bytesRequested octets from the random number generator.
+tpm2_getrandom\ - returns the next SIZE octets from the random number generator.
 .SH SYNOPSIS
-.B tpm2_getrandom[ COMMON OPTIONS ] [ TCTI OPTIONS ] [ \fB\-\-size\fR|\fB\-\-of\fR|\fB ]
+.B tpm2_getrandom[ COMMON OPTIONS ] [ TCTI OPTIONS ] [ -\-output\fR|\fB ] SIZE
 .PP
-returns the next bytesRequested octets from the random number generator.
+returns the next SIZE octets from the random number generator.
 .SH DESCRIPTION
 .B tpm2_getrandom
-returns the next bytesRequested octets from the random number generator.
+returns the next SIZE octets from the random number generator.
 .SH OPTIONS
 .TP
-\fB\-s ,\-\-size\fR
-specifies the size of the bytesRequested.
-.TP
-\fB\-o ,\-\-of\fR
+\fB\-o ,\-\-output\fR
 specifies the filename of output.
 @COMMON_OPTIONS_INCLUDE@
 @TCTI_OPTIONS_INCLUDE@
@@ -51,6 +48,7 @@ specifies the filename of output.
 .PP
 .nf
 .RS
-tpm2_getrandom -s 20 -o random.out
+tpm2_getrandom -o random.out 20
+tpm2_getrandom 8
 .RE
 .fi

--- a/test/system/test_smoking.sh
+++ b/test/system/test_smoking.sh
@@ -93,7 +93,7 @@ tpm2_akparse -f ak.pub1.out  -k akparse.out
   fi
 
 ##### getrandom & hash  
-tpm2_getrandom -s 20 -o random.out
+tpm2_getrandom -o random.out 20
   if [ $? != 0 ];then
 	fail getrandom 
   fi

--- a/test/system/test_tpm2_getrandom.sh
+++ b/test/system/test_tpm2_getrandom.sh
@@ -35,7 +35,7 @@ size=32
 
 rm -f  random.out
 
-tpm2_getrandom -s 32  -o random.out 
+tpm2_getrandom -o random.out 32
 if [ $? != 0 ];then
 	    echo "getrandom test fail, please check the environment or parameters!"
 		exit 1

--- a/test/system/test_tpm2_getrandom_func.sh
+++ b/test/system/test_tpm2_getrandom_func.sh
@@ -40,7 +40,7 @@ i=
 
 #for((i=1;i<=10;i++)); do
 for i in `seq 100`; do
-	tpm2_getrandom -s 32  -o random_"$i".out 
+	tpm2_getrandom o random_"$i".out 32
 	 if  [ $? != 0 ];then
 	  echo " create random_"$i".out fail, please check the environment or parameters!"
 	  exit 2


### PR DESCRIPTION
Make argument options optional for tpm2_getrandom. Size is a required
argument, so make it a required positional arg. Now, the only option
is -o or --output, which optionally specifies an output file. If an
output file is specified, it writes all output to that file, else
it prints hex values of the bytes to the terminal.

Fixes 251

This patch requires a significant version bump as this version of
tpm2_getrandom is not "api" compatable with older versions.

Signed-off-by: William Roberts <william.c.roberts@intel.com>