### PR TITLE
tpm2_evictcontrol: fix bug in password handling

### DIFF
--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -155,7 +155,7 @@ static bool init(int argc, char *argv[], tpm_evictcontrol_ctx *ctx) {
         case 'P': {
             bool result = password_util_copy_password(optarg, "authenticating",
                     &ctx->session_data.hmac);
-            if (result) {
+            if (!result) {
                 return false;
             }
             flags.P = 1;


### PR DESCRIPTION
Passing -P to tpm2_evictcontrol exits immediately because of mishandling the
return value of password_util_copy_password.

Fixes #249

Signed-off-by: William Roberts <william.c.roberts@intel.com>