### PR TITLE
Enlarge arrays to enable stack protector support

### DIFF
--- a/lib/pcr.c
+++ b/lib/pcr.c
@@ -97,7 +97,7 @@ int pcr_parse_selections(const char *arg, TPML_PCR_SELECTION *pcrSels) {
 }
 
 int pcr_parse_list(const char *str, int len, TPMS_PCR_SELECTION *pcrSel) {
-    char buf[3];
+    char buf[4];
     const char *strCurrent;
     int lenCurrent;
     UINT32 pcr;

--- a/lib/string-bytes.c
+++ b/lib/string-bytes.c
@@ -105,7 +105,7 @@ int hex2ByteStructure(const char *inStr, UINT16 *byteLength, BYTE *byteBuffer)
 
     for(i = 0; i < *byteLength; i++)
     {
-        char tmpStr[3] = {0};
+        char tmpStr[4] = {0};
         tmpStr[0] = inStr[i*2];
         tmpStr[1] = inStr[i*2+1];
         byteBuffer[i] = strtol(tmpStr, NULL, 16);


### PR DESCRIPTION
Not sure whether this is the best solution, but at least it allows me to build the code again, without resorting to --disable-hardening. Otherwise I get this error for the affected functions:
> error: stack protector not protecting function: all local arrays are less than 4 bytes long [-Werror=stack-protector]