### PR TITLE
tpm2_getmanufec: check for null arguments in Base64Encode and Retriev…

### DIFF
--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -338,9 +338,16 @@ out:
 
 char *Base64Encode(const unsigned char* buffer)
 {
-    printf("Calculating the Base64Encode of the hash of the Endorsement Public Key:\n");
     BIO *bio, *b64;
     BUF_MEM *bufferPtr;
+
+    printf("Calculating the Base64Encode of the hash of the Endorsement Public Key:\n");
+
+    if (buffer == NULL) {
+        LOG_ERR("HashEKPublicKey returned null");
+        return NULL;
+    }
+
     b64 = BIO_new(BIO_f_base64());
     bio = BIO_new(BIO_s_mem());
     bio = BIO_push(b64, bio);
@@ -376,9 +383,14 @@ char *Base64Encode(const unsigned char* buffer)
 
 int RetrieveEndorsementCredentials(char *b64h)
 {
-    size_t len = 1 + strlen(b64h) + strlen(EKserverAddr);
-
     int ret = -1;
+
+    if (b64h == NULL) {
+        LOG_ERR("Base64Encode returned null");
+        return ret;
+    }
+
+    size_t len = 1 + strlen(b64h) + strlen(EKserverAddr);
     char *weblink = (char *)malloc(len);
     if (!weblink) {
         LOG_ERR("Could not open file for writing: \"%s\"", ECcertFile);
@@ -461,8 +473,8 @@ int TPMinitialProvisioning(void)
         printf("TPM Manufacturer Endorsement Credential Server Address cannot be NULL\n");
         return -99;
     }
-    RetrieveEndorsementCredentials(Base64Encode(HashEKPublicKey()));
-    return 0;
+
+    return RetrieveEndorsementCredentials(Base64Encode(HashEKPublicKey()));
 }
 
 int execute_tool (int argc, char *argv[], char *envp[], common_opts_t *opts,


### PR DESCRIPTION
…eEndorsementcredentials

With HashEKPublicKey now possibly returning NULL, call chain should
check for that possibility.

Fixes: 2b6bb441f478 ("tpm2_getmanufec: fix issues")
Signed-off-by: Jerry Snitselaar <jsnitsel@redhat.com>