### PR TITLE
Adding test script to sanitize PRs on tpm2_getmanufec tool

### DIFF
--- a/test/system/test_tpm2_getmanufec.sh
+++ b/test/system/test_tpm2_getmanufec.sh
@@ -29,70 +29,41 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
 # THE POSSIBILITY OF SUCH DAMAGE.
 #;**********************************************************************;
-
 #!/bin/bash
 
-SRC_DIR=`realpath ../../tools/`
-PATH=$SRC_DIR:$PATH
+echo "3a01000001000b00b20003002000837197674484b3f81a90cc8d46a5d724fd52\
+d76e06520b64f2a1da1b331469aa000000000000000000000000000000000000\
+0000000000000000000000000000000006008000430010000000000000080000\
+000000000001c320e2f244a8601aacf3e01d26c665249935562de1da197e9e7f\
+076c469613cfb653e98ec2c386fc1d133f2c8c6cc338b732f0b208bd838a877a\
+3e5bbc3e1d4084e835c7c8906a1c05b4d2d30fdbebc1dbad950fa6b165bd4b6a\
+864603146164c0c4f59d489011ef1f928deea6e90061f3d375e5646273151ef6\
+22252098be1a4ab01dc0a12227c609fdaceb115af408d4693a6f49919774695b\
+0c12bc18a1ff7120a7337b2fb5f1951d8bb7f094d5b554c11c9523b30729fe64\
+787d0a13b9e630488dab4dfd86634a5270ec72fcc5a44dc679a8f32938dd8197\
+e29dae839f5b4ca0f5de27c9522c23c54e1c2ce57859525118bd4470b18180ee\
+f78ae4267bcd0000" | xxd -r -p > test_ek.pub
 
-pass=0
-fail=0
-
-fail_summary=""
-
-test_wrapper()
-{
-  ./$1
-  if [ $? -eq 0 ]; then
-    echo -e "\033[32m $1 pass \033[0m"
-    let "pass++"
-  else
-    echo -e "\033[31m $1 Fail \033[0m"
-    let "fail++"
-    fail_summary="$fail_summary\n$1"
-  fi
-
-  # Scripts are sloppy, perform cleanup
-  rm `find . -maxdepth 1 -type f ! -name '*.sh' ! -name 'README.md'` 2>/dev/null
-  sleep 1
-}
-
-test_wrapper test_tpm2_takeownership_all.sh
-test_wrapper test_tpm2_nv.sh
-test_wrapper test_tpm2_listpcrs.sh
-test_wrapper test_tpm2_getrandom.sh
-#test_wrapper test_tpm2_createprimary_all.sh
-#test_wrapper test_tpm2_create_all.sh
-test_wrapper test_tpm2_load.sh
-test_wrapper test_tpm2_loadexternal.sh
-test_wrapper test_tpm2_evictcontrol.sh
-test_wrapper test_tpm2_hash.sh
-test_wrapper test_tpm2_hmac.sh
-test_wrapper test_tpm2_quote.sh
-test_wrapper test_tpm2_unseal.sh
-test_wrapper test_tpm2_akparse.sh
-test_wrapper test_tpm2_certify.sh
-test_wrapper test_tpm2_evictcontrol.sh
-test_wrapper test_tpm2_getpubek.sh
-test_wrapper test_tpm2_getpubak.sh
-test_wrapper test_tpm2_makecredential.sh
-test_wrapper test_tpm2_activecredential.sh
-test_wrapper test_tpm2_readpublic.sh
-test_wrapper test_tpm2_rsaencrypt.sh
-test_wrapper test_tpm2_rsadecrypt.sh
-test_wrapper test_tpm2_encryptdecrypt.sh
-test_wrapper test_tpm2_sign.sh
-test_wrapper test_tpm2_verifysignature.sh
-test_wrapper test_tpm2_send_command.sh
-test_wrapper test_tpm2_dump_capability.sh
-test_wrapper test_tpm2_startup.sh
-test_wrapper test_tpm2_getmanufec.sh
-
-echo -e "\033[32m Tests passed: $pass \033[0m"
-echo -e "\033[31m Tests Failed: $fail  \033[0m"
-
-if [ $fail -gt 0 ]; then
-  echo -e "$fail_summary"
+tpm2_getmanufec -g 0x01 -O -N -U -E ECcert.bin -f test_ek.pub -S https://ekop.intel.com/ekcertservice/
+if [ $? != 0 ];then
+ echo "tpm2_getmanufec command failed, please check the environment or parameters!"
+ exit 1
 fi
 
-exit $fail
+if [ $(md5sum ECcert.bin| awk '{ print $1 }') != "56af9eb8a271bbf7ac41b780acd91ff5" ]; then
+ echo "Failed: retrieving endorsement certificate"
+ exit 1
+else
+ echo "Successful: retrieving endorsement certificate"
+fi
+
+if [ ! -f ECcert.bin ]; then
+ echo "ECcert.bin File not found!"
+else
+ rm -f ECcert.bin
+fi
+if [ ! -f test_ek.pub ]; then
+ echo "ECcert.bin File not found!"
+else
+ rm -f test_ek.pub
+fi 


### PR DESCRIPTION
The script exercises the offline provisioning option with a test endorsement key which has a corresponding certificate that will be retrieved from the manufacturer backend.