### PR TITLE
bootstrap: make autoreconf configurable via environment

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -1,3 +1,5 @@
 #! /bin/sh
 
-autoreconf --install --sym
+AUTORECONF=${AUTORECONF:-autoreconf}
+
+${AUTORECONF} --install --sym


### PR DESCRIPTION
The bootstrap script hard-codes the autoreconf binary. This hard-coding
makes it unfeasible to run in a sandboxed environment where those
binaries are located at non-standard paths. Typically in makefiles,
binaries can be overwritten through environment variables.
This change adjusts the bootstrap script to honor the AUTORECONF
variable if present in the environment but is able to fall back to the
previous default if not.