### PR TITLE
Fix build issues with GCC7 and OpenSSL 1.1.0

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -20,4 +20,4 @@ $ ./configure
 $ make
 $ sudo make install
 
-All executables are generated under ./src/ directory.
+All executables are generated under ./tools/ directory.

--- a/tools/main.c
+++ b/tools/main.c
@@ -61,7 +61,7 @@ main (int   argc,
         execute_man (argv[0], envp);
         fprintf (stderr,
                  "failed to load manpage, check your environment / PATH\n");
-        /* no break */
+        /* fallthrough */
     case 2:
         exit (1);
     }

--- a/tools/tpm2_dump_capability.c
+++ b/tools/tpm2_dump_capability.c
@@ -595,7 +595,7 @@ dump_tpm_capability (TPMU_CAPABILITIES    *capabilities,
     case TPM_CAP_COMMANDS:
         dump_command_attr_array (capabilities->command.commandAttributes,
                                  capabilities->command.count);
-        /* no break */
+        /* fallthrough */
     default:
         return 1;
     }


### PR DESCRIPTION
Hello,

These commits fixes some compile errors I found when building tpm2.0-tools on a Fedora 26 machine.

The first commit is just a cleanup for a left over comment in INSTALL about the src directory that no longer exists, the second commit fixes some build warnings due GCC7 complaining about not having explicit comments for case blocks falling through the next one in switch statements and the last commit adds some #ifdefery to cope with the recent API changes in the OpenSSL 1.1.0 library.

Best regards,
Javier