### PR TITLE
tpm2_unseal: fix unsealed data object serialization

### DIFF
--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -79,8 +79,8 @@ bool unseal_and_save(tpm_unseal_ctx *ctx) {
         return false;
     }
 
-    /* TODO fix serialization */
-    return files_save_bytes_to_file(ctx->outFilePath, (UINT8 *) &outData, sizeof(outData));
+    return files_save_bytes_to_file(ctx->outFilePath, (UINT8 *) outData.t.buffer,
+            outData.t.size);
 }
 
 static bool init(int argc, char *argv[], tpm_unseal_ctx *ctx) {


### PR DESCRIPTION
The tpm2_unseal tool doesn't write to the output file only the data that
was sealed, but instead writes the whole TPM2B_SENSITIVE_DATA structure
as filled by Tss2_Sys_Unseal().

That means that the buffer size is prefixed and the data is padded up to
MAX_SYM_DATA with zeros.

$ echo foobar > secret.data
$ hexdump -C -v secret.data
00000000  66 6f 6f 62 61 72 0a                              |foobar.|
00000007

After sealing and unsealing the data using the tpm2.0-tools:

$ hexdump -C -v usl_ctx_load_out_0x0004_0x0001-0x000B_0x0008
00000000  07 00 66 6f 6f 62 61 72  0a 00 00 00 00 00 00 00  |..foobar........|
00000010  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000020  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000030  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000040  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000050  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000060  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000070  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000080  00 00                                             |..|
00000082

With this change, the unsealed data matches what was sealed:

$ hexdump -C -v usl_ctx_load_out_0x0004_0x0001-0x000B_0x0008
00000000  66 6f 6f 62 61 72 0a                              |foobar.|
00000007

There was also a TODO comment about fixing serialization that I removed
because I assumed that it was referring to this same issue.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>