### PR TITLE
Allow tpm2.0-tools to fallback to a different TCTI if creating context with the default fails

### DIFF
--- a/lib/context-util.c
+++ b/lib/context-util.c
@@ -217,23 +217,34 @@ sapi_init_from_options (common_opts_t *options)
 TSS2_TCTI_CONTEXT*
 tcti_init_from_options (common_opts_t *options)
 {
-    switch (options->tcti_type) {
+    TSS2_TCTI_CONTEXT *tcti_ctx;
+
+    do {
+        switch (options->tcti_type) {
 #ifdef HAVE_TCTI_DEV
-    case DEVICE_TCTI:
-        return tcti_device_init (options->device_file);
+        case DEVICE_TCTI:
+            tcti_ctx = tcti_device_init (options->device_file);
+            break;
 #endif
 #ifdef HAVE_TCTI_SOCK
-    case SOCKET_TCTI:
-        return tcti_socket_init (options->socket_address,
-                                 options->socket_port);
+        case SOCKET_TCTI:
+            tcti_ctx = tcti_socket_init (options->socket_address,
+                                         options->socket_port);
+            break;
 #endif
 #ifdef HAVE_TCTI_TABRMD
-    case TABRMD_TCTI:
-        return tcti_tabrmd_init ();
+        case TABRMD_TCTI:
+            tcti_ctx = tcti_tabrmd_init ();
+            break;
 #endif
-    default:
-        return NULL;
-    }
+        default:
+            return NULL;
+        }
+
+        options->tcti_type++;
+    } while (tcti_ctx == NULL);
+
+    return tcti_ctx;
 }
 /*
  * Teardown the provided TCTI context. This includes finalizing the

--- a/lib/options.h
+++ b/lib/options.h
@@ -39,7 +39,8 @@
  * Default TCTI: this is a bit awkward since we allow users to enable /
  * disable TCTIs using ./configure --with/--without magic.
  * As simply put as possible:
- * if the socket TCTI is enabled, it's the default.
+ * if the tabrmd TCTI is enabled, it's the default.
+ * else if the socket TCTI is enabled it's the default.
  * else if the device TCTI is enabled it's the default.
  * We do this to preserve the current default / expected behavior (use of
  * the socket TCTI).

--- a/lib/options.h
+++ b/lib/options.h
@@ -80,14 +80,14 @@
 }
 
 typedef enum {
-#ifdef HAVE_TCTI_DEV
-    DEVICE_TCTI,
+#ifdef HAVE_TCTI_TABRMD
+    TABRMD_TCTI,
 #endif
 #ifdef HAVE_TCTI_SOCK
     SOCKET_TCTI,
 #endif
-#ifdef HAVE_TCTI_TABRMD
-    TABRMD_TCTI,
+#ifdef HAVE_TCTI_DEV
+    DEVICE_TCTI,
 #endif
     UNKNOWN_TCTI,
     N_TCTI,


### PR DESCRIPTION
This is more of an RFC than a pull-request ready to be merged. I wondered if allowing the tools to fallback to another TCTI if the default fails would be a useful feature.

There's already support to choose the TCTI either at build time (--with-tcti-*) or at runtime (using the TPM2TOOLS_TCTI_NAME en var or the --tcti option) but this can be made more transparent to the users by allowing the tools to attempt using the different available TCTIs.

For example the tools (built with both tabrmd and device TCTI support) could be ran from initramfs and access the TPM directly and access using the tpm2-abrmd resource manager once the real rootfs has been mounted, without needing to set environment variables or passing additional options.