### PR TITLE
tpm2_listpcrs: fix command line options parsing

### DIFF
--- a/tools/tpm2_listpcrs.c
+++ b/tools/tpm2_listpcrs.c
@@ -404,8 +404,9 @@ int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
     (void) opts;
     (void) envp;
 
-    while (getopt_long(argc, argv, "g:o:L:s", long_options, NULL) != -1) {
-        switch (optopt) {
+    int opt;
+    while ((opt = getopt_long(argc, argv, "g:o:L:s", long_options, NULL)) != -1) {
+        switch (opt) {
         case 'g':
             if (!string_bytes_get_uint16(optarg, &selected_algorithm)) {
                 showArgError(optarg, argv[0]);


### PR DESCRIPTION
Commit 828f0d6e851b ("tpm2_listpcrs: use dymaic tcti/sapi") besides porting
to the execute_tool() interface, did some refactoring. But unfortunately it
broke the tool command line options parsing since it uses the optopt global
variable instead of the value returned by the getopt_long() function.

Since optopt stores the last known option, the tool only works properly if
a single command line option is used:

$ tpm2_listpcrs -o pcrs.bin -L 0x4:9
Argument error: pcrs.bin
Please type "tpm2_listpcrs -h" get the usage!

$ tpm2_listpcrs -L 0x4:9

Bank/Algorithm: TPM_ALG_SHA1(0x0004)
PCR_09: 78 74 96 d6 81 50 84 ab 6b 50 69 4f 29 1c 99 b1 d6 a4 f5 28

Fixes: 828f0d6e851b ("tpm2_listpcrs: use dymaic tcti/sapi")
Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>