### PR TITLE
Adding option to create primary objects with policy based authorization

### DIFF
--- a/man/tpm2_createprimary.8.in
+++ b/man/tpm2_createprimary.8.in
@@ -31,7 +31,7 @@
 .SH NAME
 tpm2_createprimary \- Create a primary key under a primary seed or a temporary primary key under the TPM_RH_NULL hierarchy.
 .SH SYNOPSIS
-.B tpm2_createprimary [\fBCOMMON OPTIONS\fR] [\fBTCTI OPTIONS\fR] [\fB\-A\fR|\fB\-\-auth\fR=][o|p|e|n] [\fB\-P\fR|\fB\-\-pwdp\fB=][string] [\fB\-K\fR|\fB\-\-pwdk\fR=][string] [\fB\-g\fR|\fB\-\-halg\fR=][0x4|0xB|0xC|0xD|0x12] [\fB\-G\fR|\fB\-\-kalg\fR=][0x1|0x8|0x23|0x25] [\fB\-C\fR|\fB\-\-context\fR=][filepath] [\fB\-X\fR|\fB\-\-passwdInHex\fR]
+.B tpm2_createprimary [\fBCOMMON OPTIONS\fR] [\fBTCTI OPTIONS\fR] [\fB\-A\fR|\fB\-\-auth\fR=][o|p|e|n] [\fB\-P\fR|\fB\-\-pwdp\fB=][string] [\fB\-K\fR|\fB\-\-pwdk\fR=][string] [\fB\-g\fR|\fB\-\-halg\fR=][0x4|0xB|0xC|0xD|0x12] [\fB\-G\fR|\fB\-\-kalg\fR=][0x1|0x8|0x23|0x25] [\fB\-C\fR|\fB\-\-context\fR=][filepath] [\fB\-X\fR|\fB\-\-passwdInHex\fR] [\fB\-L\fR|\fB\-\-policy-file\fR=][filepath] [\fB\-E\fR|\fB\-\-enforce\-policy\fR]
 .PP
 .SH DESCRIPTION
 This command is used to create a Primary Object under one of the Primary Seeds or a Temporary Object under TPM_RH_NULL. The command uses a TPM2B_PUBLIC as a template for the object to be created. The command will create and load a Primary Object. The sensitive area is not returned.
@@ -78,6 +78,12 @@ An optional file used to store the object context returned.
 .TP
 \fB\-X\fR,\ \fB\-\-passwdInHex\fR
 A flag used to indicate that the supplied passwords are hex strings.
+.TP
+\fB\-L\fR,\ \fB\-\-policy\-file\fR=[filepath]
+An optional file input that contains the policy digest for policy based authorization of the object.
+.TP
+\fB\-E\fR,\ \fB\-\-enforce\-policy\fR
+Option to enforce policy based authorization on the created primary object.
 @COMMON_OPTIONS_INCLUDE@
 @TCTI_OPTIONS_INCLUDE@
 .SH ENVIRONMENT

--- a/test/system/test_tpm2_createprimary_all.sh
+++ b/test/system/test_tpm2_createprimary_all.sh
@@ -36,7 +36,6 @@ gAlg=
 GAlg=
 
 rm createprimary.error.log rf
-
 for gAlg in 0x04 0x0B 0x0C 0x0D 0x12
     do 
         for GAlg in 0x01 0x08 0x23 0x25
@@ -52,3 +51,25 @@ for gAlg in 0x04 0x0B 0x0C 0x0D 0x12
         done
 done
 
+#test for createprimary objects with policy authorization structures
+echo "f28230c080bbe417141199e36d18978228d8948fc10a6a24921b9eba6bb1d988" \
+| xxd -r -p > policy.bin
+
+tpm2_createprimary  -A o -G 0x1 -g 0xb -E -C prim.ctx -L policy.bin
+if [ $? != 0 ];then
+ exit 1
+fi
+
+tpm2_readpublic -c prim.ctx -o testprim.pub
+if [ $? != 0 ];then
+ exit 1
+fi
+
+cmp -i 14:0 -n 32 testprim.pub policy.bin -s
+if [ $? != 0 ];then
+ echo "Failed: createprimary with policy authorization structure" >> createprimary.error.log
+ exit 1
+fi
+
+rm -f prim.ctx policy.bin testprim.pub
+exit 0


### PR DESCRIPTION
This commit should enable creating primary objects with authorization based on policies with an option to enforce policy.