### PR TITLE
Allow tpm2_create to read data to be sealed from stdin

### DIFF
--- a/lib/files.c
+++ b/lib/files.c
@@ -37,8 +37,35 @@ static bool get_file_size(FILE *fp, long *file_size, const char *path) {
     return true;
 }
 
-bool files_load_bytes_from_file(const char *path, UINT8 *buf, UINT16 *size) {
+static bool read_bytes_from_file(FILE *f, UINT8 *buf, UINT16 *size,
+                                 const char *path) {
+    long file_size;
+    bool result = get_file_size(f, &file_size, path);
+    if (!result) {
+        /* get_file_size() logs errors */
+        return false;
+    }
 
+    /* max is bounded on UINT16 */
+    if (file_size > *size) {
+        LOG_ERR(
+                "File \"%s\" size is larger than buffer, got %ld expected less than %u",
+                path, file_size, *size);
+        return false;
+    }
+
+    result = files_read_bytes(f, buf, file_size);
+    if (!result) {
+        LOG_ERR("Could not read data from file \"%s\"", path);
+        return false;
+    }
+
+    *size = file_size;
+
+    return true;
+}
+
+bool files_load_bytes_from_file(const char *path, UINT8 *buf, UINT16 *size) {
     if (!buf || !size || !path) {
         return false;
     }
@@ -49,33 +76,18 @@ bool files_load_bytes_from_file(const char *path, UINT8 *buf, UINT16 *size) {
         return false;
     }
 
-    long file_size;
-    bool result = get_file_size(f, &file_size, path);
-    if (!result) {
-        /* get_file_size() logs errors */
-        goto err;
-    }
+    bool result = read_bytes_from_file(f, buf, size, path);
 
-    /* max is bounded on UINT16 */
-    if (file_size > *size) {
-        LOG_ERR(
-                "File \"%s\" size is larger than buffer, got %ld expected less than %u",
-                path, file_size, *size);
-        goto err;
-    }
-
-    result = files_read_bytes(f, buf, file_size);
-    if (!result) {
-        LOG_ERR("Could not read data from file \"%s\"", path);
-        goto err;
-    }
-
-    *size = file_size;
-    /* result set on files_read_bytes */
-
-err:
     fclose(f);
     return result;
+}
+
+bool files_load_bytes_from_stdin(UINT8 *buf, UINT16 *size) {
+    if (!buf || !size) {
+        return false;
+    }
+
+    return read_bytes_from_file(stdin, buf, size, "stdin");
 }
 
 bool files_save_bytes_to_file(const char *path, UINT8 *buf, UINT16 size) {

--- a/lib/files.h
+++ b/lib/files.h
@@ -24,6 +24,21 @@
 bool files_load_bytes_from_file(const char *path, UINT8 *buf, UINT16 *size);
 
 /**
+ * Reads a series of bytes from the standard input as a byte array. This is similar to
+ * files_read_bytes(), but it calculates the size to read for the caller. Size is both
+ * an input and output value where the size value is the max buffer size on call and
+ * the returned size is how much was read.
+ *
+ * @param buf
+ *  The buffer to read the data into
+ * @param size
+ *  The max size of the buffer on call, and the size of the data read on return.
+ * @return
+ *  True on success, false otherwise.
+ */
+bool files_load_bytes_from_stdin(UINT8 *buf, UINT16 *size);
+
+/**
  * Similar to files_write_bytes(), in that it writes an array of bytes to disk,
  * but this routine opens and closes the file on the callers behalf.
  * @param path

--- a/man/tpm2_create.8.in
+++ b/man/tpm2_create.8.in
@@ -63,7 +63,7 @@ algorithm associated with this object  0x0001 TPM_ALG_RSA   0x0008 TPM_ALG_KEYED
 object attributes, optional
 .TP
 \fB\-I ,\-\-inFile\fR
-data file to be sealed, optional
+data file to be sealed, optional. If file is -, read from stdin.
 .TP
 \fB\-L ,\-\-pol\fR
 the input policy file, optional

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -347,10 +347,16 @@ execute_tool (int              argc,
             break;
         case 'I':
             inSensitive.t.sensitive.data.t.size = sizeof(inSensitive.t.sensitive.data) - 2;
-            if(!files_load_bytes_from_file(optarg, inSensitive.t.sensitive.data.t.buffer, &inSensitive.t.sensitive.data.t.size))
-            {
-                returnVal = -7;
-                break;
+            if (!strcmp(optarg, "-")) {
+                if (!files_load_bytes_from_stdin(inSensitive.t.sensitive.data.t.buffer,
+                                                 &inSensitive.t.sensitive.data.t.size)) {
+                    returnVal = -7;
+                    break;
+                }
+            } else if(!files_load_bytes_from_file(optarg, inSensitive.t.sensitive.data.t.buffer,
+                                               &inSensitive.t.sensitive.data.t.size)) {
+                    returnVal = -7;
+                    break;
             }
             I_flag = 1;
             printf("inSensitive.t.sensitive.data.t.size = %d\n",inSensitive.t.sensitive.data.t.size);


### PR DESCRIPTION
It may be important to never store sensitive data in the file system, but the tpm2_create tool only allows to pass a data to be sealed as a file using the -I option.

So this pull request adds support for tpm2_create to read the data to be sealed from the standard input instead.