### PR TITLE
test_tpm2_unseal.sh cleanups and fixes

### DIFF
--- a/test/system/test_tpm2_unseal.sh
+++ b/test/system/test_tpm2_unseal.sh
@@ -56,27 +56,21 @@ if [ $? != 0 ];then
 echo "createprimary fail, please check the environment or parameters!"
 exit 1
 fi
-#./tpm2_create -g 0x000B -G 0x0008 -o opu9.out -O opr9.out -c context.p9.out -I secret.data
+
 tpm2_create -g $alg_create_obj -G $alg_create_key -o $file_unseal_key_pub -O $file_unseal_key_priv  -I $file_input_data -c $file_primary_key_ctx
 if [ $? != 0 ];then
 echo "create fail, please check the environment or parameters!"
 exit 1
 fi
-#./tpm2_load -c context.p9.out  -u opu9.out -r opr9.out -n name.load9.out -C context_load_out9.out 
+
 tpm2_load -c $file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -C $file_unseal_key_ctx
 if [ $? != 0 ];then
 echo "load fail, please check the environment or parameters!"
 exit 1
 fi
 
-#tpm2_unseal -c context_load_out1.out -o usl.data.out
 tpm2_unseal -c $file_unseal_key_ctx -o $file_unseal_output_data
 if [ $? != 0 ];then
 echo "unseal fail, please check the environment or parameters!"
 exit 1
 fi
-
-###handle test blocked 
-##tpm2_evictcontrol -A p -c $file_unseal_key_ctx  -S 0x81010015 --Fail to evict
-##tpm2_evictcontrol -A o -c context_load_out4  -S 0x81010015 (0x285)
-##tpm2_unseal -H 0x81010015 -o usl_handle

--- a/test/system/test_tpm2_unseal.sh
+++ b/test/system/test_tpm2_unseal.sh
@@ -51,7 +51,7 @@ echo "12345678" > $file_input_data
 fi 
 
 tpm2_takeownership -c
-tpm2_createprimary -A p -g $alg_primary_obj -G $alg_primary_key -C $file_primary_key_ctx
+tpm2_createprimary -A e -g $alg_primary_obj -G $alg_primary_key -C $file_primary_key_ctx
 if [ $? != 0 ];then
 echo "createprimary fail, please check the environment or parameters!"
 exit 1

--- a/test/system/test_tpm2_unseal.sh
+++ b/test/system/test_tpm2_unseal.sh
@@ -74,3 +74,11 @@ if [ $? != 0 ];then
 echo "unseal fail, please check the environment or parameters!"
 exit 1
 fi
+
+if ! cmp -s $file_unseal_output_data $file_input_data; then
+    echo "unseal fail, output differs from sealed data!"
+    exit 1
+fi
+
+echo "tpm2_unseal success"
+exit 0


### PR DESCRIPTION
This pull request contains some fixes and cleanups for the test_tpm2_unseal.sh test.

Javier Martinez Canillas (3):
      tpm2_unseal: use endorsement instead of platform hierarchy for test
      tpm2_unseal: remove commented out code leftovers
      tpm2_unseal: print a success message if the test finish successfully