### PR TITLE
test_tpm2_unseal: fix invalid conditional expression

### DIFF
--- a/test/system/test_tpm2_unseal.sh
+++ b/test/system/test_tpm2_unseal.sh
@@ -75,7 +75,8 @@ echo "unseal fail, please check the environment or parameters!"
 exit 1
 fi
 
-if [ ! cmp -s $file_unseal_output_data $file_input_data ]; then
+cmp -s $file_unseal_output_data $file_input_data
+if [ $? != 0 ]; then
     echo "unseal fail, output differs from sealed data!"
     exit 1
 fi


### PR DESCRIPTION
The commit 780c3bcdd8ec ("tpm2_unseal: print a success message if the test
finish successfully") originally was using the bash if command construct,
but was modified when merged to have the command inside brackets and match
the rest of the script.

Unfortunately commands can't be inside [] since they are used only to test
conditional expressions and not command exit code. This leads to following
error when executing the test:

./test_tpm2_unseal.sh: line 78: [: too many arguments

So take the commands out of the if statement and instead use an expression
to test the latest command exit code. This also matches what's done in the
rest of the script.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>