### PR TITLE
Allow tpm2_unseal to write the unsealed data to stdout

### DIFF
--- a/man/tpm2_unseal.8.in
+++ b/man/tpm2_unseal.8.in
@@ -48,7 +48,7 @@ filename for item context
 item handle password, optional
 .TP
 \fB\-o ,\-\-outfile\fR
-Output file name, containing the unsealed data
+Output file name, containing the unsealed data. Defaults to stdout if not specified.
 .TP
 \fB\-X ,\-\-passwdInHex\fR
 passwords given by any options are hex format.

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -79,8 +79,13 @@ bool unseal_and_save(tpm_unseal_ctx *ctx) {
         return false;
     }
 
-    return files_save_bytes_to_file(ctx->outFilePath, (UINT8 *) outData.t.buffer,
-            outData.t.size);
+    if (ctx->outFilePath) {
+        return files_save_bytes_to_file(ctx->outFilePath, (UINT8 *)
+                                        outData.t.buffer, outData.t.size);
+    } else {
+        return files_write_bytes(stdout, (UINT8 *) outData.t.buffer,
+                                 outData.t.size);
+    }
 }
 
 static bool init(int argc, char *argv[], tpm_unseal_ctx *ctx) {
@@ -103,7 +108,6 @@ static bool init(int argc, char *argv[], tpm_unseal_ctx *ctx) {
     union {
         struct {
             UINT8 H : 1;
-            UINT8 o : 1;
             UINT8 c : 1;
             UINT8 P : 1;
         };
@@ -140,7 +144,6 @@ static bool init(int argc, char *argv[], tpm_unseal_ctx *ctx) {
                 return false;
             }
             ctx->outFilePath = optarg;
-            flags.o = 1;
         }
             break;
         case 'c':
@@ -162,8 +165,8 @@ static bool init(int argc, char *argv[], tpm_unseal_ctx *ctx) {
         }
     }
 
-    if (!((flags.H || flags.c) && flags.o)) {
-        LOG_ERR("Expected options (H or c) and o");
+    if (!(flags.H || flags.c)) {
+        LOG_ERR("Expected options H or c");
         return false;
     }
 

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -49,7 +49,7 @@ typedef struct tpm_unseal_ctx tpm_unseal_ctx;
 struct tpm_unseal_ctx {
     TPMS_AUTH_COMMAND sessionData;
     TPMI_DH_OBJECT itemHandle;
-    char outFilePath[PATH_MAX];
+    char *outFilePath;
     TSS2_SYS_CONTEXT *sapi_context;
 };
 
@@ -139,7 +139,7 @@ static bool init(int argc, char *argv[], tpm_unseal_ctx *ctx) {
             if (result) {
                 return false;
             }
-            snprintf(ctx->outFilePath, sizeof(ctx->outFilePath), "%s", optarg);
+            ctx->outFilePath = optarg;
             flags.o = 1;
         }
             break;


### PR DESCRIPTION
This pull request is similar to commit 686951ed0b30 ("tpm2_create: allow read data to be sealed from the standard input"), the idea is to do the same for tpm2_unseal so the sensible data never is stored.

The first commit is just a cleanup, but makes the logic simpler for the second commit since we just test if ctx->outFilePath has been set to know if the user passed the -o option.