### PR TITLE
Fix remaining tools doing unnecessary options arguments copies

### DIFF
--- a/tools/tpm2_akparse.c
+++ b/tools/tpm2_akparse.c
@@ -47,8 +47,8 @@
 
 typedef struct tpm_akparse_ctx tpm_akparse_ctx;
 struct tpm_akparse_ctx {
-    char ak_data_file_path[PATH_MAX];
-    char ak_key_file_path[PATH_MAX];
+    char *ak_data_file_path;
+    char *ak_key_file_path;
 };
 
 static bool is_big_endian() {
@@ -191,14 +191,14 @@ static bool init(int argc, char *argv[], tpm_akparse_ctx *ctx) {
                 LOG_ERR("Please input the file that used to be parsed.");
                 return false;
             }
-            snprintf(ctx->ak_data_file_path, sizeof(ctx->ak_data_file_path), "%s", optarg);
+            ctx->ak_data_file_path = optarg;
             break;
         case 'k':
             if (!optarg) {
                 LOG_ERR("Please input the file that used to save ak key.");
                 return false;
             }
-            snprintf(ctx->ak_key_file_path, sizeof(ctx->ak_key_file_path), "%s", optarg);
+            ctx->ak_key_file_path = optarg;
             break;
         case ':':
             LOG_ERR("Argument %c needs a value!\n", optopt);

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -246,8 +246,8 @@ execute_tool (int              argc,
     TPMI_ALG_HASH nameAlg;
     TPMI_DH_OBJECT parentHandle;
     UINT32 objectAttributes = 0;
-    char opuFilePath[PATH_MAX] = {0};
-    char oprFilePath[PATH_MAX] = {0};
+    char *opuFilePath = NULL;
+    char *oprFilePath = NULL;
     char *contextParentFilePath = NULL;
 
     setbuf(stdout, NULL);
@@ -376,7 +376,7 @@ execute_tool (int              argc,
             is_policy_enforced = true;
             break;
         case 'o':
-            snprintf(opuFilePath, sizeof(opuFilePath), "%s", optarg);
+            opuFilePath = optarg;
             if(files_does_file_exist(opuFilePath) != 0)
             {
                 returnVal = -9;
@@ -385,7 +385,7 @@ execute_tool (int              argc,
             o_flag = 1;
             break;
         case 'O':
-            snprintf(oprFilePath, sizeof(oprFilePath), "%s", optarg);
+            oprFilePath = optarg;
             if(files_does_file_exist(oprFilePath) != 0)
             {
                 returnVal = -10;

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -53,7 +53,7 @@ struct tpm_encrypt_decrypt_ctx {
     TPMI_YES_NO is_decrypt;
     TPMI_DH_OBJECT key_handle;
     TPM2B_MAX_BUFFER data;
-    char out_file_path[PATH_MAX];
+    char *out_file_path;
     TSS2_SYS_CONTEXT *sapi_context;
 };
 
@@ -143,14 +143,14 @@ static bool init(int argc, char *argv[], tpm_encrypt_decrypt_ctx *ctx) {
             if (!result) {
                 LOG_ERR("Could not convert keyhandle to number, got: \"%s\"",
                         optarg);
-                goto out;
+                return result;
             }
             flags.k = 1;
             break;
         case 'P':
             result = password_tpm2_util_copy_password(optarg, "key", &ctx->session_data.hmac);
             if (!result) {
-                goto out;
+                return result;
             }
             flags.P = 1;
             break;
@@ -161,36 +161,31 @@ static bool init(int argc, char *argv[], tpm_encrypt_decrypt_ctx *ctx) {
                 ctx->is_decrypt = NO;
             } else {
                 showArgError(optarg, argv[0]);
-                goto out;
+                return result;
             }
             break;
         case 'I':
             ctx->data.t.size = sizeof(ctx->data) - 2;
             result = files_load_bytes_from_file(optarg, ctx->data.t.buffer, &ctx->data.t.size);
             if (!result) {
-                goto out;
+                return result;
             }
             flags.I = 1;
             break;
         case 'o':
             result = files_does_file_exist(optarg);
             if (result) {
-                goto out;
+                return result;
             }
-            snprintf(ctx->out_file_path, sizeof(ctx->out_file_path), "%s",
-                    optarg);
+            ctx->out_file_path = optarg;
             flags.o = 1;
             break;
         case 'c':
             if (contextKeyFile) {
                 LOG_ERR("Multiple specifications of -c");
-                goto out;
+                return result;
             }
-            contextKeyFile = strdup(optarg);
-            if (!contextKeyFile) {
-                LOG_ERR("OOM");
-                goto out;
-            }
+            contextKeyFile = optarg;
             flags.c = 1;
             break;
         case 'X':
@@ -198,35 +193,30 @@ static bool init(int argc, char *argv[], tpm_encrypt_decrypt_ctx *ctx) {
             break;
         case ':':
             LOG_ERR("Argument %c needs a value!\n", optopt);
-            goto out;
+            return result;
         case '?':
             LOG_ERR("Unknown Argument: %c\n", optopt);
-            goto out;
+            return result;
         default:
             LOG_ERR("?? getopt returned character code 0%o ??\n", opt);
-            goto out;
+            return result;
         }
     }
 
     if (!((flags.k || flags.c) && flags.I && flags.o)) {
         LOG_ERR("Invalid arguments");
-        goto out;
+        return result;
     }
 
     if (flags.c) {
         result = file_load_tpm_context_from_file(ctx->sapi_context, &ctx->key_handle, contextKeyFile);
         if (!result) {
-            goto out;
+            return result;
         }
     }
 
-    result = password_tpm2_util_to_auth(&ctx->session_data.hmac, is_hex_passwd, "key",
+    return password_tpm2_util_to_auth(&ctx->session_data.hmac, is_hex_passwd, "key",
             &ctx->session_data.hmac);
-
-out:
-    free(contextKeyFile);
-
-    return result;
 }
 
 int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -108,7 +108,7 @@ static bool init(int argc, char *argv[], tpm_evictcontrol_ctx *ctx) {
         UINT8 all;
     } flags = { .all = 0 };
 
-    char contextFile[PATH_MAX];
+    char *contextFile = NULL;
 
     bool is_hex_passwd = false;
 
@@ -165,7 +165,7 @@ static bool init(int argc, char *argv[], tpm_evictcontrol_ctx *ctx) {
         }
             break;
         case 'c':
-            snprintf(contextFile, sizeof(contextFile), "%s", optarg);
+            contextFile = optarg;
             flags.c = 1;
             break;
         case 'X':

--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -53,15 +53,15 @@
 #include "options.h"
 #include "tpm_hash.h"
 
-char outputFile[PATH_MAX];
-char ownerPasswd[sizeof(TPMU_HA)];
-char endorsePasswd[sizeof(TPMU_HA)];
-char ekPasswd[sizeof(TPMU_HA)];
+char *outputFile;
+char *ownerPasswd;
+char *endorsePasswd;
+char *ekPasswd;
 bool hexPasswd = false;
 TPM_HANDLE persistentHandle;
 UINT32 algorithmType = TPM_ALG_RSA;
 
-char ECcertFile[PATH_MAX];
+char *ECcertFile;
 char *EKserverAddr = NULL;
 unsigned int nonPersistentRead = 0;
 unsigned int SSL_NO_VERIFY = 0;
@@ -532,47 +532,47 @@ int execute_tool (int argc, char *argv[], char *envp[], common_opts_t *opts,
                 case 'H':
                     if (!tpm2_util_string_to_uint32(optarg, &persistentHandle)) {
                         printf("\nPlease input the handle used to make EK persistent(hex) in correct format.\n");
-                        goto out;
+                        return return_val;
                     }
                     break;
 
                 case 'e':
                     if (optarg == NULL || (strlen(optarg) >= sizeof(TPMU_HA)) ) {
                         printf("\nPlease input the endorsement password(optional,no more than %d characters).\n", (int)sizeof(TPMU_HA) - 1);
-                        goto out;
+                        return return_val;
                     }
-                    snprintf(endorsePasswd, sizeof(endorsePasswd), "%s", optarg);
+                    endorsePasswd = optarg;
                     break;
 
                 case 'o':
                     if (optarg == NULL || (strlen(optarg) >= sizeof(TPMU_HA)) ) {
                         printf("\nPlease input the owner password(optional,no more than %d characters).\n", (int)sizeof(TPMU_HA) - 1);
-                        goto out;
+                        return return_val;
                     }
-                    snprintf(ownerPasswd, sizeof(ownerPasswd), "%s", optarg);
+                    ownerPasswd = optarg;
                     break;
 
                 case 'P':
                     if (optarg == NULL || (strlen(optarg) >= sizeof(TPMU_HA)) ) {
                         printf("\nPlease input the EK password(optional,no more than %d characters).\n", (int)sizeof(TPMU_HA) - 1);
-                        goto out;
+                        return return_val;
                     }
-                    snprintf(ekPasswd, sizeof(ekPasswd), "%s", optarg);
+                    ekPasswd = optarg;
                     break;
 
                 case 'g':
                     if (!tpm2_util_string_to_uint32(optarg, &algorithmType)) {
                         printf("\nPlease input the algorithm type in correct format.\n");
-                        goto out;
+                        return return_val;
                     }
                     break;
 
                 case 'f':
                     if (optarg == NULL ) {
                         printf("\nPlease input the file used to save the pub ek.\n");
-                        goto out;
+                        return return_val;
                     }
-                    snprintf(outputFile, sizeof(outputFile), "%s", optarg);
+                    outputFile = optarg;
                     break;
 
                 case 'X':
@@ -582,9 +582,9 @@ int execute_tool (int argc, char *argv[], char *envp[], common_opts_t *opts,
                 case 'E':
                     if (optarg == NULL ) {
                         printf("\nPlease input the file used to save the EC Certificate retrieved from server\n");
-                        goto out;
+                        return return_val;
                     }
-                    snprintf(ECcertFile, sizeof(ECcertFile), "%s", optarg);
+                    ECcertFile = optarg;
                     break;
                 case 'N':
                     nonPersistentRead = 1;
@@ -601,13 +601,9 @@ int execute_tool (int argc, char *argv[], char *envp[], common_opts_t *opts,
                 case 'S':
                     if (EKserverAddr) {
                         printf("Multiple specifications of -S\n");
-                        goto out;
+                        return return_val;
                     }
-                    EKserverAddr = strdup(optarg);
-                    if (EKserverAddr == NULL) {
-                        LOG_ERR ("Memory allocation failed.");
-                        goto out;
-                    }
+                    EKserverAddr = optarg;
                     printf("TPM Manufacturer EK provisioning address -- %s\n", EKserverAddr);
                     break;
             }
@@ -626,13 +622,8 @@ int execute_tool (int argc, char *argv[], char *envp[], common_opts_t *opts,
     }
 
     if (return_val && provisioning_return_val) {
-        goto out;
+        return return_val;
     }
 
-    return_val = 0;
-
-out:
-    free(EKserverAddr);
-
-    return return_val;
+    return 0;
 }

--- a/tools/tpm2_getpubak.c
+++ b/tools/tpm2_getpubak.c
@@ -59,8 +59,8 @@ struct getpubak_context {
         TPM2B_AUTH owner;
     } passwords;
     bool hexPasswd;
-    char outputFile[PATH_MAX];
-    char aknameFile[PATH_MAX];
+    char *outputFile;
+    char *aknameFile;
     UINT32 algorithmType;
     UINT32 digestAlg;
     UINT32 signAlg;
@@ -493,7 +493,7 @@ static bool init(int argc, char *argv[], getpubak_context *ctx) {
                         "Please specify the output file used to save the pub ek.");
                 return false;
             }
-            snprintf(ctx->outputFile, sizeof(ctx->outputFile), "%s", optarg);
+            ctx->outputFile = optarg;
             break;
         case 'n':
             if (!optarg) {
@@ -501,7 +501,7 @@ static bool init(int argc, char *argv[], getpubak_context *ctx) {
                         "Please specify the output file used to save the ak name.");
                 return false;
             }
-            snprintf(ctx->aknameFile, sizeof(ctx->aknameFile), "%s", optarg);
+            ctx->aknameFile = optarg;
             break;
         case 'X':
             ctx->hexPasswd = true;

--- a/tools/tpm2_getpubek.c
+++ b/tools/tpm2_getpubek.c
@@ -52,7 +52,7 @@ struct getpubek_context {
         TPM2B_AUTH endorse;
         TPM2B_AUTH ek;
     } passwords;
-    char out_file_path[PATH_MAX];
+    char *out_file_path;
     TPM_HANDLE persistent_handle;
     UINT32 algorithm;
     TSS2_SYS_CONTEXT *sapi_context;
@@ -319,8 +319,7 @@ static bool init(int argc, char *argv[], char *envp[], getpubek_context *ctx) {
                 LOG_ERR("Please specify an output file to save the pub ek to.");
                 return false;
             }
-            snprintf(ctx->out_file_path, sizeof(ctx->out_file_path), "%s",
-                    optarg);
+            ctx->out_file_path = optarg;
             break;
         case 'X':
             ctx->passwords.is_hex = true;

--- a/tools/tpm2_getrandom.c
+++ b/tools/tpm2_getrandom.c
@@ -48,7 +48,7 @@
 typedef struct tpm_random_ctx tpm_random_ctx;
 struct tpm_random_ctx {
     bool output_file_specified;
-    char output_file[PATH_MAX];
+    char *output_file;
     UINT16 num_of_bytes;
     TSS2_SYS_CONTEXT *sapi_context;
 };
@@ -99,7 +99,7 @@ static bool init(int argc, char *argv[], tpm_random_ctx *ctx) {
         switch (opt) {
         case 'o':
             ctx->output_file_specified = true;
-            snprintf(ctx->output_file, sizeof(ctx->output_file), "%s", optarg);
+            ctx->output_file = optarg;
             break;
         case ':':
             LOG_ERR("Argument %c needs a value!\n", optopt);
@@ -132,7 +132,7 @@ int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
     tpm_random_ctx ctx = {
             .output_file_specified = false,
             .num_of_bytes = 0,
-            .output_file = { 0 },
+            .output_file = NULL,
             .sapi_context = sapi_context
     };
 

--- a/tools/tpm2_hash.c
+++ b/tools/tpm2_hash.c
@@ -49,8 +49,8 @@ struct tpm_hash_ctx {
     TPMI_RH_HIERARCHY hierarchyValue;
     TPM2B_MAX_BUFFER data;
     TPMI_ALG_HASH  halg;
-    char outHashFilePath[PATH_MAX];
-    char outTicketFilePath[PATH_MAX];
+    char *outHashFilePath;
+    char *outTicketFilePath;
     TSS2_SYS_CONTEXT *sapi_context;
 };
 
@@ -177,8 +177,7 @@ static bool init(int argc, char *argv[], tpm_hash_ctx *ctx) {
             break;
         case 'o':
             flags++;
-            snprintf(ctx->outHashFilePath, sizeof(ctx->outHashFilePath), "%s",
-                    optarg);
+            ctx->outHashFilePath = optarg;
             res = files_does_file_exist(ctx->outHashFilePath);
             if (res) {
                 return false;
@@ -186,8 +185,7 @@ static bool init(int argc, char *argv[], tpm_hash_ctx *ctx) {
             break;
         case 't':
             flags++;
-            snprintf(ctx->outTicketFilePath, sizeof(ctx->outTicketFilePath),
-                    "%s", optarg);
+            ctx->outTicketFilePath = optarg;
             res = files_does_file_exist(ctx->outTicketFilePath);
             if (res) {
                 return false;

--- a/tools/tpm2_load.c
+++ b/tools/tpm2_load.c
@@ -118,7 +118,7 @@ execute_tool (int              argc,
     TPM2B_PUBLIC  inPublic;
     TPM2B_PRIVATE inPrivate;
     UINT16 size;
-    char outFilePath[PATH_MAX] = {0};
+    char *outFilePath = NULL;
     char *contextFile = NULL;
     char *contextParentFilePath = NULL;
 
@@ -193,7 +193,7 @@ execute_tool (int              argc,
             r_flag = 1;
             break;
         case 'n':
-            snprintf(outFilePath, sizeof(outFilePath), "%s", optarg);
+            outFilePath = optarg;
             if(files_does_file_exist(outFilePath))
             {
                 returnVal = -5;

--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -46,7 +46,7 @@
 
 typedef struct tpm_loadexternal_ctx tpm_loadexternal_ctx;
 struct tpm_loadexternal_ctx {
-    char context_file_path[PATH_MAX];
+    char *context_file_path;
     TPMI_RH_HIERARCHY hierarchy_value;
     TPM_HANDLE rsa2048_handle;
     TPM2B_PUBLIC public_key;
@@ -164,7 +164,7 @@ static bool init(int argc, char *argv[], tpm_loadexternal_ctx *ctx) {
             ctx->has_private_key = true;
         } break;
         case 'C':
-            snprintf(ctx->context_file_path, sizeof(ctx->context_file_path), "%s", optarg);
+            ctx->context_file_path = optarg;
             ctx->save_to_context_file = true;
             break;
         case ':':

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -54,7 +54,7 @@ struct tpm_nvwrite_ctx {
     UINT8 nv_buffer[MAX_NV_INDEX_SIZE];
     TPM2B_AUTH handle_passwd;
     bool hex_passwd;
-    char input_file[PATH_MAX];
+    char *input_file;
     TSS2_SYS_CONTEXT *sapi_context;
 };
 
@@ -173,7 +173,7 @@ static bool init(int argc, char *argv[], tpm_nvwrite_ctx *ctx) {
             }
             break;
         case 'f':
-            snprintf(ctx->input_file, sizeof(ctx->input_file), "%s", optarg);
+            ctx->input_file = optarg;
             break;
         case 'P':
             result = password_tpm2_util_copy_password(optarg, "handle password",

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -59,7 +59,7 @@ TPMS_AUTH_COMMAND sessionData = {
 };
 
 bool hexPasswd = false;
-char outFilePath[PATH_MAX];
+char *outFilePath;
 TPM2B_DATA qualifyingData = TPM2B_EMPTY_INIT;
 TPML_PCR_SELECTION  pcrSelections;
 
@@ -394,7 +394,7 @@ int execute_tool (int argc, char *argv[], char *envp[], common_opts_t *opts,
             L_flag = 1;
             break;
         case 'o':
-            snprintf(outFilePath, sizeof(outFilePath), "%s", optarg);
+            outFilePath = optarg;
             if(files_does_file_exist(outFilePath))
             {
                 showArgError(optarg, argv[0]);

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -48,7 +48,7 @@
 typedef struct tpm_readpub_ctx tpm_readpub_ctx;
 struct tpm_readpub_ctx {
     TPMI_DH_OBJECT objectHandle;
-    char outFilePath[PATH_MAX];
+    char *outFilePath;
     TSS2_SYS_CONTEXT *sapi_context;
 };
 
@@ -121,7 +121,7 @@ static bool init(int argc, char *argv[], tpm_readpub_ctx * ctx) {
 
     int opt = -1;
     bool result;
-    char context_file[PATH_MAX] = {0};
+    char *context_file = NULL;
     while ((opt = getopt_long(argc, argv, short_options, long_options, NULL))
             != -1) {
         switch (opt) {
@@ -137,11 +137,11 @@ static bool init(int argc, char *argv[], tpm_readpub_ctx * ctx) {
             if (result) {
                 return false;
             }
-            snprintf(ctx->outFilePath, sizeof(ctx->outFilePath), "%s", optarg);
+            ctx->outFilePath = optarg;
             flags.o = 1;
             break;
         case 'c':
-            snprintf(context_file, sizeof(context_file), "%s", optarg);
+            context_file = optarg;
             flags.c = 1;
             break;
         }
@@ -171,7 +171,7 @@ int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
 
     tpm_readpub_ctx ctx = {
             .objectHandle = 0,
-            .outFilePath = { 0 },
+            .outFilePath = NULL,
             .sapi_context = sapi_context
     };
 

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -120,7 +120,7 @@ static bool init(int argc, char *argv[], tpm_rsadecrypt_ctx *ctx) {
 
     int opt;
     bool is_hex_passwd = false;
-    char context_key_file[PATH_MAX];
+    char *context_key_file = NULL;
     while ((opt = getopt_long(argc, argv, optstring, long_options, NULL))
             != -1) {
         switch (opt) {
@@ -163,7 +163,7 @@ static bool init(int argc, char *argv[], tpm_rsadecrypt_ctx *ctx) {
         }
             break;
         case 'c':
-            snprintf(context_key_file, sizeof(context_key_file), "%s", optarg);
+            context_key_file = optarg;
             flags.c = 1;
             break;
         case 'X':

--- a/tools/tpm2_rsaencrypt.c
+++ b/tools/tpm2_rsaencrypt.c
@@ -110,7 +110,7 @@ static bool init(int argc, char *argv[], tpm_rsaencrypt_ctx *ctx) {
     } flags = { .all = 0 };
 
     int opt;
-    char context_key_file[PATH_MAX];
+    char *context_key_file = NULL;
     while ((opt = getopt_long(argc, argv, optstring, long_options, NULL))
             != -1) {
         switch (opt) {
@@ -144,7 +144,7 @@ static bool init(int argc, char *argv[], tpm_rsaencrypt_ctx *ctx) {
         }
             break;
         case 'c':
-            snprintf(context_key_file, sizeof(context_key_file), "%s", optarg);
+            context_key_file = optarg;
             flags.c = 1;
             break;
         case ':':

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -52,7 +52,7 @@ struct tpm_sign_ctx {
     TPMS_AUTH_COMMAND sessionData;
     TPMI_DH_OBJECT keyHandle;
     TPMI_ALG_HASH halg;
-    char outFilePath[PATH_MAX];
+    char *outFilePath;
     BYTE *msg;
     UINT16 length;
     TSS2_SYS_CONTEXT *sapi_context;
@@ -206,8 +206,8 @@ static bool init(int argc, char *argv[], tpm_sign_ctx *ctx) {
 
     int opt;
     bool hexPasswd = false;
-    char contextKeyFile[PATH_MAX];
-    char inMsgFileName[PATH_MAX];
+    char *contextKeyFile = NULL;
+    char *inMsgFileName = NULL;
     while ((opt = getopt_long(argc, argv, optstring, long_options, NULL)) != -1) {
         switch (opt) {
         case 'k': {
@@ -240,7 +240,7 @@ static bool init(int argc, char *argv[], tpm_sign_ctx *ctx) {
         }
             break;
         case 'm':
-            snprintf(inMsgFileName, sizeof(inMsgFileName), "%s", optarg);
+            inMsgFileName = optarg;
             flags.m = 1;
             break;
         case 't': {
@@ -258,12 +258,12 @@ static bool init(int argc, char *argv[], tpm_sign_ctx *ctx) {
             if (result) {
                 return false;
             }
-            snprintf(ctx->outFilePath, sizeof(ctx->outFilePath), "%s", optarg);
+            ctx->outFilePath = optarg;
             flags.s = 1;
         }
             break;
         case 'c':
-            snprintf(contextKeyFile, sizeof(contextKeyFile), "%s", optarg);
+            contextKeyFile = optarg;
             flags.c = 1;
             break;
         case 'X':

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -116,7 +116,7 @@ static bool init(int argc, char *argv[], tpm_unseal_ctx *ctx) {
 
     int opt;
     bool hexPasswd = false;
-    char contextItemFile[PATH_MAX];
+    char *contextItemFile = NULL;
     while ((opt = getopt_long(argc, argv, optstring, long_options, NULL)) != -1) {
         switch (opt) {
         case 'H': {
@@ -147,7 +147,7 @@ static bool init(int argc, char *argv[], tpm_unseal_ctx *ctx) {
         }
             break;
         case 'c':
-            snprintf(contextItemFile, sizeof(contextItemFile), "%s", optarg);
+            contextItemFile = optarg;
             flags.c = 1;
             break;
         case 'X':


### PR DESCRIPTION
This contains fixes for all the remaining offenders of issue #260. The only file that I didn't fix was tpm2_createpolicy.c to avoid creating a conflict for @idesai, since he has a pending pull request refactoring that file.