### PR TITLE
tpm2_unseal: Adding support for session handle input for policy based  authorization

### DIFF
--- a/man/tpm2_unseal.8.in
+++ b/man/tpm2_unseal.8.in
@@ -30,7 +30,7 @@
 .SH NAME
 tpm2_unseal\ - returns the data in a loaded Sealed Data Object.
 .SH SYNOPSIS
-.B tpm2_unseal[ COMMON OPTIONS ] [ TCTI OPTIONS ] [ \fB\-\-item\fR|\fB\-\-itemContext\fR|\fB\-\-pwdi\fR|\fB\-\-outfile\fR|\fB\-\-passwdInHex\fR|\fB ]
+.B tpm2_unseal[ COMMON OPTIONS ] [ TCTI OPTIONS ] [ \fB\-\-item\fR|\fB\-\-itemContext\fR|\fB\-\-pwdi\fR|\fB\-\-outfile\fR|\fB\-\-passwdInHex\fR|\fB\-\-input-session-handle\fR|\fB ]
 .PP
 returns the data in a loaded Sealed Data Object.
 .SH DESCRIPTION
@@ -52,6 +52,9 @@ Output file name, containing the unsealed data. Defaults to stdout if not specif
 .TP
 \fB\-X ,\-\-passwdInHex\fR
 passwords given by any options are hex format.
+.TP
+\fB\-S ,\-\-input-session-handle\fR
+Optional Input session handle from a policy session for authorization.
 @COMMON_OPTIONS_INCLUDE@
 @TCTI_OPTIONS_INCLUDE@
 .SH ENVIRONMENT\@TCTI_ENVIRONMENT_INCLUDE@

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -90,12 +90,13 @@ bool unseal_and_save(tpm_unseal_ctx *ctx) {
 
 static bool init(int argc, char *argv[], tpm_unseal_ctx *ctx) {
 
-    static const char *optstring = "H:P:o:c:X";
+    static const char *optstring = "H:P:o:c:S:X";
     static const struct option long_options[] = {
       {"item",1,NULL,'H'},
       {"pwdi",1,NULL,'P'},
       {"outfile",1,NULL,'o'},
       {"itemContext",1,NULL,'c'},
+      {"input-session-handle",1,NULL,'S'},
       {"passwdInHex",0,NULL,'X'},
       {0,0,0,0}
     };
@@ -122,7 +123,7 @@ static bool init(int argc, char *argv[], tpm_unseal_ctx *ctx) {
         case 'H': {
             bool result = tpm2_util_string_to_uint32(optarg, &ctx->itemHandle);
             if (!result) {
-                LOG_ERR("Could not cobvert item handle to number, got: \"%s\"",
+                LOG_ERR("Could not convert item handle to number, got: \"%s\"",
                         optarg);
                 return false;
             }
@@ -149,6 +150,16 @@ static bool init(int argc, char *argv[], tpm_unseal_ctx *ctx) {
         case 'c':
             contextItemFile = optarg;
             flags.c = 1;
+            break;
+        case 'S': {
+            bool result = tpm2_util_string_to_uint32(optarg,
+                &ctx->sessionData.sessionHandle);
+            if (!result) {
+                LOG_ERR("Could not convert session handle to number, got: \"%s\"",
+                        optarg);
+                return false;
+            }
+        }
             break;
         case 'X':
             hexPasswd = true;


### PR DESCRIPTION
The PR has a dependency on the PR #334, the new create policy tool. the new option is only relevant for device tcti or any other tcti that can sustain sessions between application runs.
(a test is pending for this PR. Works with socket tcti)