### PR TITLE
tpm2_create: Adding support for session handle input for policy based authorization

### DIFF
--- a/man/tpm2_create.8.in
+++ b/man/tpm2_create.8.in
@@ -31,7 +31,7 @@
 tpm2_create\ - create an object that can be loaded into a TPM using tpm2_load. The object
 will need to be loaded before it may be used.
 .SH SYNOPSIS
-.B tpm2_create[ COMMON OPTIONS ] [ TCTI OPTIONS ] [ \fB\-\-parent\fR|\fB\-\-contextParent\fR|\fB\-\-pwdp\fR|\fB\-\-pwdk\fR|\fB\-\-halg\fR|\fB\-\-kalg\fR|\fB\-\-objectAttribute\fR|\fB\-\-inFile\fR|\fB\-\-policy\-file\fR|\fB\-\-enforce-policy\fR|\fB\-\-opu\fR|\fB\-\-opr\fR|\fB\-\-passwdInHex\fR|\fB ]
+.B tpm2_create[ COMMON OPTIONS ] [ TCTI OPTIONS ] [ \fB\-\-parent\fR|\fB\-\-contextParent\fR|\fB\-\-pwdp\fR|\fB\-\-pwdk\fR|\fB\-\-halg\fR|\fB\-\-kalg\fR|\fB\-\-objectAttribute\fR|\fB\-\-inFile\fR|\fB\-\-policy\-file\fR|\fB\-\-enforce-policy\fR|\fB\-\-opu\fR|\fB\-\-opr\fR|\fB\-\-passwdInHex\fR|\fB\-\-input-session-handle\fR|\fB ]
 .PP
 create an object that can be loaded into a TPM using tpm2_load. The object
 will need to be loaded before it may be used.
@@ -79,6 +79,9 @@ the output file which contains the private key,  optional
 .TP
 \fB\-X ,\-\-passwdInHex\fR
 passwords given by any options are hex format.
+.TP
+\fB\-S ,\-\-input-session-handle\fR
+Optional Input session handle from a policy session for authorization. [Only for device-tcti]
 @COMMON_OPTIONS_INCLUDE@
 @TCTI_OPTIONS_INCLUDE@
 .SH ENVIRONMENT\@TCTI_ENVIRONMENT_INCLUDE@

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -46,6 +46,7 @@
 #include "files.h"
 #include "main.h"
 #include "options.h"
+#include "log.h"
 
 TSS2_SYS_CONTEXT *sysContext;
 TPMS_AUTH_COMMAND sessionData = {
@@ -254,7 +255,7 @@ execute_tool (int              argc,
     setvbuf (stdout, NULL, _IONBF, BUFSIZ);
 
     int opt = -1;
-    const char *optstring = "H:P:K:g:G:A:I:L:o:O:c:XE";
+    const char *optstring = "H:P:K:g:G:A:I:L:o:O:c:S:XE";
     static struct option long_options[] = {
       {"parent",1,NULL,'H'},
       {"pwdp",1,NULL,'P'},
@@ -269,6 +270,7 @@ execute_tool (int              argc,
       {"opr",1,NULL,'O'},
       {"contextParent",1,NULL,'c'},
       {"passwdInHex",0,NULL,'X'},
+      {"input-session-handle",1,NULL,'S'},
       {0,0,0,0}
     };
 
@@ -372,6 +374,13 @@ execute_tool (int              argc,
             }
             L_flag = 1;
             break;
+        case 'S':
+             if (!tpm2_util_string_to_uint32(optarg, &sessionData.sessionHandle)) {
+                 LOG_ERR("Could not convert session handle to number, got: \"%s\"",
+                         optarg);
+                 returnVal = 1;
+             }
+             break;
         case 'E':
             is_policy_enforced = true;
             break;


### PR DESCRIPTION
The PR has a dependency on the PR #334, the new create policy tool. the new option is only relevant for device tcti or any other tcti that can sustain sessions between application runs.
(a test is pending for this PR)