### PR TITLE
tpm2_createprimary: Adding support for session handle input for policy based authorization

### DIFF
--- a/man/tpm2_createprimary.8.in
+++ b/man/tpm2_createprimary.8.in
@@ -31,7 +31,7 @@
 .SH NAME
 tpm2_createprimary \- Create a primary key under a primary seed or a temporary primary key under the TPM_RH_NULL hierarchy.
 .SH SYNOPSIS
-.B tpm2_createprimary [\fBCOMMON OPTIONS\fR] [\fBTCTI OPTIONS\fR] [\fB\-A\fR|\fB\-\-auth\fR=][o|p|e|n] [\fB\-P\fR|\fB\-\-pwdp\fB=][string] [\fB\-K\fR|\fB\-\-pwdk\fR=][string] [\fB\-g\fR|\fB\-\-halg\fR=][0x4|0xB|0xC|0xD|0x12] [\fB\-G\fR|\fB\-\-kalg\fR=][0x1|0x8|0x23|0x25] [\fB\-C\fR|\fB\-\-context\fR=][filepath] [\fB\-X\fR|\fB\-\-passwdInHex\fR] [\fB\-L\fR|\fB\-\-policy-file\fR=][filepath] [\fB\-E\fR|\fB\-\-enforce\-policy\fR]
+.B tpm2_createprimary [\fBCOMMON OPTIONS\fR] [\fBTCTI OPTIONS\fR] [\fB\-A\fR|\fB\-\-auth\fR=][o|p|e|n] [\fB\-P\fR|\fB\-\-pwdp\fB=][string] [\fB\-K\fR|\fB\-\-pwdk\fR=][string] [\fB\-g\fR|\fB\-\-halg\fR=][0x4|0xB|0xC|0xD|0x12] [\fB\-G\fR|\fB\-\-kalg\fR=][0x1|0x8|0x23|0x25] [\fB\-C\fR|\fB\-\-context\fR=][filepath] [\fB\-X\fR|\fB\-\-passwdInHex\fR] [\fB\-L\fR|\fB\-\-policy-file\fR=][filepath] [\fB\-E\fR|\fB\-\-enforce\-policy\fR] [\fB\-S\fR|\fB\-\-input\-session\-handle\fR]
 .PP
 .SH DESCRIPTION
 This command is used to create a Primary Object under one of the Primary Seeds or a Temporary Object under TPM_RH_NULL. The command uses a TPM2B_PUBLIC as a template for the object to be created. The command will create and load a Primary Object. The sensitive area is not returned.
@@ -84,6 +84,9 @@ An optional file input that contains the policy digest for policy based authoriz
 .TP
 \fB\-E\fR,\ \fB\-\-enforce\-policy\fR
 Option to enforce policy based authorization on the created primary object.
+.TP
+\fB\-S\fR,\ \fB\-\-input-session-handle\fR
+Optional Input session handle from a policy session for authorization. [Only for device-tcti]
 @COMMON_OPTIONS_INCLUDE@
 @TCTI_OPTIONS_INCLUDE@
 .SH ENVIRONMENT

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -195,7 +195,7 @@ execute_tool (int               argc,
     setvbuf (stdout, NULL, _IONBF, BUFSIZ);
 
     int opt = -1;
-    const char *optstring = "A:P:K:g:G:C:L:EX";
+    const char *optstring = "A:P:K:g:G:C:L:S:EX";
     static struct option long_options[] = {
       {"auth",1,NULL,'A'},
       {"pwdp",1,NULL,'P'},
@@ -206,6 +206,7 @@ execute_tool (int               argc,
       {"passwdInHex",0,NULL,'X'},
       {"policy-file",1,NULL,'L'},
       {"enforce-policy",1,NULL,'E'},
+      {"input-session-handle",1,NULL,'S'},
       {0,0,0,0}
     };
 
@@ -303,6 +304,13 @@ execute_tool (int               argc,
             break;
         case 'E':
             is_policy_enforced = true;
+            break;
+        case 'S':
+            if (!tpm2_util_string_to_uint32(optarg, &sessionData.sessionHandle)) {
+                LOG_ERR("Could not convert session handle to number, got: \"%s\"",
+                        optarg);
+                returnVal = 1;
+            }
             break;
         case ':':
 //              printf("Argument %c needs a value!\n",optopt);


### PR DESCRIPTION
The PR has a dependency on the PR #334, the new create policy tool. the new option is only relevant for device tcti or any other tcti that can sustain sessions between application runs.
(a test is pending for this PR.)