### PR TITLE
tpm2_dictionarylockout: Adding support for session handle input for policy based authorization

### DIFF
--- a/man/tpm2_dictionarylockout.8.in
+++ b/man/tpm2_dictionarylockout.8.in
@@ -30,7 +30,7 @@
 .SH NAME
 tpm2_dictionarylockout\ - setup dictionary-attack-lockout parameters or clear dictionary-attack-lockout state, if any passwd option is missing, assume NULL.
 .SH SYNOPSIS
-.B tpm2_dictionarylockout[ COMMON OPTIONS ] [ TCTI OPTIONS ] [ \fB\-\-setup-parameters\fR|\fB\-\-clear-lockout\fR|\fB\-\-lockout-passwd\fR|\fB\-\-lockout-recovery-time\fR|\fB\-\-recovery-time\fR|\fB\-\-max-tries\fR|\fB ]
+.B tpm2_dictionarylockout[ COMMON OPTIONS ] [ TCTI OPTIONS ] [ \fB\-\-setup-parameters\fR|\fB\-\-clear-lockout\fR|\fB\-\-lockout-passwd\fR|\fB\-\-lockout-recovery-time\fR|\fB\-\-recovery-time\fR|\fB\-\-max-tries\fR|\fB\-\-input-session-handle\fR|\fB ]
 .PP
 setup dictionary-attack-lockout parameters or clear dictionary-attack-lockout state, if any passwd option is missing, assume NULL.
 .SH DESCRIPTION
@@ -55,6 +55,9 @@ specifies the wait time in seconds before another DA-protected-object authentica
 .TP
 \fB\-n ,\-\-max-tries\fR
 specifies the maximum number of allowed authentication attempts on DA-protected-object ; after which DA is activated.
+.TP
+\fB\-S ,\-\-input-session-handle\fR
+Optional Input session handle from a policy session for authorization. [Only for device-tcti]
 @COMMON_OPTIONS_INCLUDE@
 @TCTI_OPTIONS_INCLUDE@
 .SH ENVIRONMENT\@TCTI_ENVIRONMENT_INCLUDE@


### PR DESCRIPTION
The PR has a dependency on the PR #334, the new create policy tool. the new option is only relevant for device tcti or any other tcti that can sustain sessions between application runs.
(a test is pending for this PR.)