### PR TITLE
main: add tpm2_startup() command to all tools

### DIFF
--- a/tools/main.c
+++ b/tools/main.c
@@ -76,6 +76,23 @@ main (int   argc,
     sapi_context = sapi_init_from_options (&opts);
     if (sapi_context == NULL)
         exit (1);
+
+    /*
+     * Call Tpm2_startup() as not all TCTIs/Environments handle this for you.
+     * For instance, going at the device tcti with no resource manager, a
+     * common issue is to forget the startup command.
+     * Valid Errors:
+     * TPM_RC_SUCCESS (0x00)
+     * TPM_RC_INITIALIZE(0x100)
+     * TPM_RC_2 (0x2XX) - Session errors
+     */
+    TPM_RC rc = Tss2_Sys_Startup (sapi_context, TPM_SU_CLEAR);
+    if (!(rc == TPM_RC_SUCCESS || rc == TPM_RC_INITIALIZE
+            || (rc >= 0x200 && rc <= 0x299))) {
+        LOG_WARN("The TPM Startup command returned an unexpected error: %u",
+                rc);
+    }
+
     /*
      * Call the specific tool, all tools implement this function instead of
      * 'main'.


### PR DESCRIPTION
A common issue when using a device directly, is that, potentially,
no startup command was issued. A tpm cannot be used until a
startup command is issued.

The tools do not call startup implicitly, so add that to the tools
and ignore initialized or session errors. However, log at the
warning level any other return codes.

Fixes: #296

Signed-off-by: William Roberts <william.c.roberts@intel.com>