### PR TITLE
Allow  tpm2_unseal to unseal an object using a PCR policy for authentication

### DIFF
--- a/man/tpm2_unseal.8.in
+++ b/man/tpm2_unseal.8.in
@@ -30,12 +30,14 @@
 .SH NAME
 tpm2_unseal\ - returns the data in a loaded Sealed Data Object.
 .SH SYNOPSIS
-.B tpm2_unseal[ COMMON OPTIONS ] [ TCTI OPTIONS ] [ \fB\-\-item\fR|\fB\-\-itemContext\fR|\fB\-\-pwdi\fR|\fB\-\-outfile\fR|\fB\-\-passwdInHex\fR|\fB\-\-input-session-handle\fR|\fB ]
+.B tpm2_unseal[ COMMON OPTIONS ] [ TCTI OPTIONS ] [ \fB\-\-item\fR|\fB\-\-itemContext\fR|\fB\-\-pwdi\fR|\fB\-\-outfile\fR|\fB\-\-passwdInHex\fR|\fB\-\-input-session-handle\fR|\fB\-\-set-list\fR|\fB\-\-pcr-input-file\fR|\fB ]
 .PP
 returns the data in a loaded Sealed Data Object.
 .SH DESCRIPTION
 .B tpm2_unseal
 returns the data in a loaded Sealed Data Object.
+
+The \-\-set-list and \-\-pcr-input-file options should only be used for simple PCR authentication policies. For more complex policies the tools should be ran in an execution environment that keeps the session context alive and pass that session using the \-\-input-session-handle option.
 .SH OPTIONS
 .TP
 \fB\-H ,\-\-item\fR
@@ -55,6 +57,12 @@ passwords given by any options are hex format.
 .TP
 \fB\-S ,\-\-input-session-handle\fR
 Optional Input session handle from a policy session for authorization.
+.TP
+\fB\-L\fR,\ \fB\-\-set-list\fR
+The list of pcr banks and selected PCRs' ids (0~23) for each bank.
+.TP
+\fB\-F\fR,\ \fB\-\-pcr-input-file\fR
+Optional Path or Name of the file containing expected pcr values for the specified index. Default is to read the current PCRs per the set list.
 @COMMON_OPTIONS_INCLUDE@
 @TCTI_OPTIONS_INCLUDE@
 .SH ENVIRONMENT\@TCTI_ENVIRONMENT_INCLUDE@
@@ -66,5 +74,6 @@ Optional Input session handle from a policy session for authorization.
 tpm2_unseal -H 0x81010001 -P abc123 -o <outPutFileName>
 tpm2_unseal -c item.context -P abc123 -o <outPutFileName>
 tpm2_unseal -H 0x81010001 -P 123abc -X -o <outPutFileName>
+tpm2_unseal -c item.context -L 0x4:0,1,2 -F <pcrFileName>
 .RE
 .fi

--- a/test/system/test_tpm2_unseal.sh
+++ b/test/system/test_tpm2_unseal.sh
@@ -34,20 +34,29 @@ alg_primary_obj=0x0004
 alg_primary_key=0x0001
 alg_create_obj=0x000B
 alg_create_key=0x0008
+alg_pcr_policy=0x0004
 
+pcr_index=0
+
+obj_attr=0x492 # fixedTPM, fixedParent, adminWithPolicy, noDA
+
+file_pcr_value=pcr.bin
 file_input_data=secret.data
+file_policy=policy.data
 file_primary_key_ctx=context.p_"$alg_primary_obj"_"$alg_primary_key"
 file_unseal_key_pub=opu_"$alg_create_obj"_"$alg_create_key"
 file_unseal_key_priv=opr_"$alg_create_obj"_"$alg_create_key"
 file_unseal_key_ctx=ctx_load_out_"$alg_primary_obj"_"$alg_primary_key"-"$alg_create_obj"_"$alg_create_key"
 file_unseal_key_name=name.load_"$alg_primary_obj"_"$alg_primary_key"-"$alg_create_obj"_"$alg_create_key"
 file_unseal_output_data=usl_"$file_unseal_key_ctx"
-  
+
+secret="12345678"
+
 rm $file_primary_key_ctx $file_unseal_key_pub $file_unseal_key_priv $file_unseal_key_ctx $file_unseal_key_name $file_unseal_output_data -rf
 
 if [ ! -e "$file_input_data" ]   
   then    
-echo "12345678" > $file_input_data
+echo $secret > $file_input_data
 fi 
 
 tpm2_takeownership -c
@@ -77,6 +86,45 @@ fi
 
 cmp -s $file_unseal_output_data $file_input_data
 if [ $? != 0 ]; then
+    echo "unseal fail, output differs from sealed data!"
+    exit 1
+fi
+
+# Test using a PCR policy for auth
+
+rm $file_unseal_key_pub $file_unseal_key_priv $file_unseal_key_name
+
+tpm2_listpcrs -L ${alg_pcr_policy}:${pcr_index} -o $file_pcr_value
+if [ $? != 0 ];then
+    echo "create raw pcr output fail, please check the environment or parameters!"
+    exit 1
+fi
+
+tpm2_createpolicy -P -L ${alg_pcr_policy}:${pcr_index} -F $file_pcr_value -f $file_policy
+if [ $? != 0 ];then
+    echo "create policy fail, please check the environment or parameters!"
+    exit 1
+fi
+
+tpm2_create -g $alg_create_obj -G $alg_create_key -o $file_unseal_key_pub -O $file_unseal_key_priv -I- -c $file_primary_key_ctx -L $file_policy -A $obj_attr <<< $secret
+if [ $? != 0 ];then
+    echo "create object with policy fail, please check the environment or parameters!"
+    exit 1
+fi
+
+tpm2_load -c $file_primary_key_ctx  -u $file_unseal_key_pub  -r $file_unseal_key_priv -n $file_unseal_key_name -C $file_unseal_key_ctx
+if [ $? != 0 ];then
+    echo "load fail, please check the environment or parameters!"
+    exit 1
+fi
+
+unsealed=`tpm2_unseal -c $file_unseal_key_ctx -L ${alg_pcr_policy}:${pcr_index} -F $file_pcr_value`
+if [ $? != 0 ];then
+    echo "unseal fail, please check the environment or parameters!"
+    exit 1
+fi
+
+if [ "$unsealed" != "$secret" ];then
     echo "unseal fail, output differs from sealed data!"
     exit 1
 fi

--- a/test/unit/test_string_bytes.c
+++ b/test/unit/test_string_bytes.c
@@ -31,7 +31,7 @@
 #include <cmocka.h>
 #include <sapi/tpm20.h>
 
-#include "../../lib/tpm2_util.h"
+#include "tpm2_util.h"
 
 static void test_is_big_endian(void **state) {
 

--- a/tools/tpm2_activatecredential.c
+++ b/tools/tpm2_activatecredential.c
@@ -41,12 +41,12 @@
 
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
 #include "password_util.h"
+#include "tpm2_util.h"
 #include "tpm_session.h"
 
 typedef struct tpm_activatecred_ctx tpm_activatecred_ctx;

--- a/tools/tpm2_akparse.c
+++ b/tools/tpm2_akparse.c
@@ -39,11 +39,11 @@
 #include <getopt.h>
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
+#include "tpm2_util.h"
 
 typedef struct tpm_akparse_ctx tpm_akparse_ctx;
 struct tpm_akparse_ctx {

--- a/tools/tpm2_dictionarylockout.c
+++ b/tools/tpm2_dictionarylockout.c
@@ -38,11 +38,11 @@
 
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_util.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
 #include "password_util.h"
+#include "tpm2_util.h"
 
 typedef struct dictionarylockout_ctx dictionarylockout_ctx;
 struct dictionarylockout_ctx {

--- a/tools/tpm2_encryptdecrypt.c
+++ b/tools/tpm2_encryptdecrypt.c
@@ -40,12 +40,12 @@
 
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
 #include "password_util.h"
+#include "tpm2_util.h"
 
 typedef struct tpm_encrypt_decrypt_ctx tpm_encrypt_decrypt_ctx;
 struct tpm_encrypt_decrypt_ctx {

--- a/tools/tpm2_evictcontrol.c
+++ b/tools/tpm2_evictcontrol.c
@@ -41,12 +41,12 @@
 
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
 #include "password_util.h"
+#include "tpm2_util.h"
 
 typedef struct tpm_evictcontrol_ctx tpm_evictcontrol_ctx;
 struct tpm_evictcontrol_ctx {

--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -46,12 +46,12 @@
 #include <openssl/sha.h>
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_util.h"
 #include "log.h"
 #include "files.h"
 #include "main.h"
 #include "options.h"
 #include "tpm_hash.h"
+#include "tpm2_util.h"
 
 char *outputFile;
 char *ownerPasswd;

--- a/tools/tpm2_getpubak.c
+++ b/tools/tpm2_getpubak.c
@@ -39,12 +39,12 @@
 
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
 #include "password_util.h"
+#include "tpm2_util.h"
 #include "tpm_session.h"
 
 typedef struct getpubak_context getpubak_context;

--- a/tools/tpm2_getpubek.c
+++ b/tools/tpm2_getpubek.c
@@ -38,11 +38,11 @@
 
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
 #include "password_util.h"
+#include "tpm2_util.h"
 
 typedef struct getpubek_context getpubek_context;
 struct getpubek_context {

--- a/tools/tpm2_getrandom.c
+++ b/tools/tpm2_getrandom.c
@@ -38,12 +38,12 @@
 #include <limits.h>
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_util.h"
 #include "log.h"
 #include "files.h"
 #include "main.h"
 #include "options.h"
 #include "password_util.h"
+#include "tpm2_util.h"
 
 typedef struct tpm_random_ctx tpm_random_ctx;
 struct tpm_random_ctx {

--- a/tools/tpm2_hash.c
+++ b/tools/tpm2_hash.c
@@ -38,11 +38,11 @@
 
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
+#include "tpm2_util.h"
 
 typedef struct tpm_hash_ctx tpm_hash_ctx;
 struct tpm_hash_ctx {

--- a/tools/tpm2_listpcrs.c
+++ b/tools/tpm2_listpcrs.c
@@ -38,11 +38,11 @@
 #include <getopt.h>
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_util.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
 #include "pcr.h"
+#include "tpm2_util.h"
 
 typedef struct tpm2_algorithm tpm2_algorithm;
 struct tpm2_algorithm {

--- a/tools/tpm2_listpersistent.c
+++ b/tools/tpm2_listpersistent.c
@@ -40,10 +40,10 @@
 
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_util.h"
 #include "files.h"
 #include "main.h"
 #include "options.h"
+#include "tpm2_util.h"
 
 int debugLevel = 0;
 

--- a/tools/tpm2_loadexternal.c
+++ b/tools/tpm2_loadexternal.c
@@ -38,11 +38,11 @@
 #include <getopt.h>
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
+#include "tpm2_util.h"
 
 typedef struct tpm_loadexternal_ctx tpm_loadexternal_ctx;
 struct tpm_loadexternal_ctx {

--- a/tools/tpm2_makecredential.c
+++ b/tools/tpm2_makecredential.c
@@ -39,11 +39,11 @@
 
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_util.h"
 #include "log.h"
 #include "files.h"
 #include "main.h"
 #include "options.h"
+#include "tpm2_util.h"
 
 #define tpm_makecred_ctx_empty_init { \
 		.rsa2048_handle = 0, \

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -38,12 +38,12 @@
 
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
 #include "password_util.h"
+#include "tpm2_util.h"
 
 typedef struct tpm_nvdefine_ctx tpm_nvdefine_ctx;
 struct tpm_nvdefine_ctx {

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -38,11 +38,11 @@
 
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_util.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
 #include "password_util.h"
+#include "tpm2_util.h"
 
 typedef struct tpm_nvread_ctx tpm_nvread_ctx;
 struct tpm_nvread_ctx {

--- a/tools/tpm2_nvreadlock.c
+++ b/tools/tpm2_nvreadlock.c
@@ -39,11 +39,11 @@
 
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_util.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
 #include "password_util.h"
+#include "tpm2_util.h"
 
 typedef struct tpm_nvreadlock_ctx tpm_nvreadlock_ctx;
 struct tpm_nvreadlock_ctx {

--- a/tools/tpm2_nvrelease.c
+++ b/tools/tpm2_nvrelease.c
@@ -37,11 +37,11 @@
 
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_util.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
 #include "password_util.h"
+#include "tpm2_util.h"
 
 typedef struct tpm_nvrelease_ctx tpm_nvrelease_ctx;
 struct tpm_nvrelease_ctx {

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -39,12 +39,12 @@
 
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_util.h"
 #include "log.h"
 #include "files.h"
 #include "main.h"
 #include "options.h"
 #include "password_util.h"
+#include "tpm2_util.h"
 
 typedef struct tpm_nvwrite_ctx tpm_nvwrite_ctx;
 struct tpm_nvwrite_ctx {

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -38,12 +38,12 @@
 #include <getopt.h>
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
 #include "password_util.h"
+#include "tpm2_util.h"
 
 typedef struct tpm_readpub_ctx tpm_readpub_ctx;
 struct tpm_readpub_ctx {

--- a/tools/tpm2_rsadecrypt.c
+++ b/tools/tpm2_rsadecrypt.c
@@ -38,12 +38,12 @@
 #include <getopt.h>
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
 #include "password_util.h"
+#include "tpm2_util.h"
 
 typedef struct tpm_rsadecrypt_ctx tpm_rsadecrypt_ctx;
 struct tpm_rsadecrypt_ctx {

--- a/tools/tpm2_rsaencrypt.c
+++ b/tools/tpm2_rsaencrypt.c
@@ -38,11 +38,11 @@
 #include <getopt.h>
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
+#include "tpm2_util.h"
 
 typedef struct tpm_rsaencrypt_ctx tpm_rsaencrypt_ctx;
 struct tpm_rsaencrypt_ctx {

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -38,12 +38,12 @@
 #include <getopt.h>
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
 #include "password_util.h"
+#include "tpm2_util.h"
 #include "tpm_hash.h"
 
 typedef struct tpm_sign_ctx tpm_sign_ctx;

--- a/tools/tpm2_takeownership.c
+++ b/tools/tpm2_takeownership.c
@@ -41,11 +41,11 @@
 
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_util.h"
 #include "log.h"
 #include "options.h"
 #include "main.h"
 #include "password_util.h"
+#include "tpm2_util.h"
 
 typedef struct password password;
 struct password {

--- a/tools/tpm2_unseal.c
+++ b/tools/tpm2_unseal.c
@@ -38,12 +38,12 @@
 #include <getopt.h>
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
 #include "password_util.h"
+#include "tpm2_util.h"
 
 typedef struct tpm_unseal_ctx tpm_unseal_ctx;
 struct tpm_unseal_ctx {

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -40,11 +40,11 @@
 
 #include <sapi/tpm20.h>
 
-#include "../lib/tpm2_util.h"
 #include "files.h"
 #include "log.h"
 #include "main.h"
 #include "options.h"
+#include "tpm2_util.h"
 #include "tpm_hash.h"
 
 typedef struct tpm2_verifysig_ctx tpm2_verifysig_ctx;


### PR DESCRIPTION
This pull request adds support for tpm2_unseal to authenticate using a PCR policy so objects can be unsealed only when a PCR policy is satisfied.

The first commit is just a cleanup, the second is the one that adds the support and the third one extends the test_tpm2_unseal.sh test case to cover the object creation and unsealing using a PCR policy for auth.