### PR TITLE
tpm2_nvread: Adding a warning to the user about max read size

### DIFF
--- a/man/tpm2_nvread.8.in
+++ b/man/tpm2_nvread.8.in
@@ -29,6 +29,7 @@
 .TH tpm2_nvread 8 "DECEMBER 2016" Intel "tpm2.0-tools"
 .SH NAME
 tpm2_nvread\ - read content from NV index, if any passwd option is missing, assume NULL.
+A maximum of 1024 bytes can be read at a time. Use offset option to read more data.
 .SH SYNOPSIS
 .B tpm2_nvread[ COMMON OPTIONS ] [ TCTI OPTIONS ] [ \fB\-\-index\fR|\fB\-\-authHandle\fR|\fB\-\-handlePasswd\fR|\fB\-\-size\fR|\fB\-\-offset\fR|\fB\-\-passwdInHex\fR|\fB\-\-input-session-handle\fR|\fB  ]
 .PP

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -165,6 +165,11 @@ static bool init(int argc, char *argv[], tpm_nvread_ctx *ctx) {
                         optarg);
                 return false;
             }
+            if (ctx->size_to_read > 1024) {
+                LOG_ERR("Maximum read size allowed is 1024."
+                    " Use offset option to continue reading data.\n");
+                return false;
+            }
             break;
         case 'o':
             result = tpm2_util_string_to_uint32(optarg, &ctx->offset);


### PR DESCRIPTION
tpm2_nvread: Adding a warning to the user about max read size