### PR TITLE
Fixing compiler warnings with GCC 4.7.2

### DIFF
--- a/lib/log.c
+++ b/lib/log.c
@@ -11,16 +11,10 @@
 
 static log_level current_log_level = log_level_warning;
 
-bool
+void
 log_set_level (log_level value)
 {
-    bool result = false;
-    if (value >= log_level_error || value <= log_level_verbose) {
-        current_log_level = value;
-        result = true;
-    }
-
-    return result;
+    current_log_level = value;
 }
 
 static const char *

--- a/lib/log.h
+++ b/lib/log.h
@@ -38,10 +38,8 @@ enum log_level
  * Sets the log level so only messages <= to it print.
  * @param level
  *  The logging level to set.
- * @return
- *  True if i succeeds, false if level is out of bounds.
  */
-bool
+void
 log_set_level (log_level level);
 
 void

--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -447,7 +447,7 @@ int RetrieveEndorsementCredentials(char *b64h)
         goto out_easy_cleanup;
     }
 
-    rc = curl_easy_setopt(curl, CURLOPT_VERBOSE, respfile);
+    rc = curl_easy_setopt(curl, CURLOPT_VERBOSE, respfile != NULL);
     if (rc != CURLE_OK) {
         LOG_ERR("curl_easy_setopt for CURLOPT_VERBOSE failed: %s", curl_easy_strerror(rc));
         goto out_easy_cleanup;


### PR DESCRIPTION
This is the correction of [pull request 357](https://github.com/01org/tpm2.0-tools/pull/357). Since the commit message had to be corrected, I ve decided to close the previous pull-request and create a new one:
- Considering remarks of @martinezjavier  and @williamcroberts 
- Correcting the commit message