### PR TITLE
Idesai tpm2 nvwrite size fix and add nice-name handling for nv attributes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -93,7 +93,8 @@ lib_libcommon_a_SOURCES = \
     lib/tpm_hmac.c \
     lib/tpm_kdfa.c \
     lib/tpm_session.c \
-    lib/tpm2_util.c
+    lib/tpm2_util.c \
+    lib/tpm2_nv_util.c
 
 tools_tpm2_create_SOURCES = tools/tpm2_create.c tools/main.c
 tools_tpm2_createprimary_SOURCES = tools/tpm2_createprimary.c tools/main.c
@@ -145,7 +146,8 @@ check_PROGRAMS = \
     test/unit/tpm2-rc-entry_unit \
     test/unit/test_string_bytes \
     test/unit/test_files \
-    test/unit/test_tpm2_header
+    test/unit/test_tpm2_header \
+    test/unit/test_tpm2_nv_util
 
 test_unit_tpm2_rc_decode_unit_CFLAGS  = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
 test_unit_tpm2_rc_decode_unit_LDADD   = $(CMOCKA_LIBS) $(LIB_COMMON)
@@ -167,6 +169,10 @@ test_unit_test_files_SOURCES  = test/unit/test_files.c
 test_unit_test_tpm2_header_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
 test_unit_test_tpm2_header_LDADD    = $(CMOCKA_LIBS) $(LIB_COMMON)
 test_unit_test_tpm2_header_SOURCES  = test/unit/test_tpm2_header.c
+
+test_unit_test_tpm2_nv_util_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
+test_unit_test_tpm2_nv_util_LDADD    = $(CMOCKA_LIBS) $(LIB_COMMON)
+test_unit_test_tpm2_nv_util_SOURCES  = test/unit/test_tpm2_nv_util.c
 
 endif
 

--- a/lib/tpm2_nv_util.c
+++ b/lib/tpm2_nv_util.c
@@ -310,3 +310,12 @@ bool tpm2_nv_util_attrs_to_val(char *attribute_list, TPMA_NV *nvattrs) {
 
     return true;
 }
+
+TPM_RC tpm2_util_nv_read_public(TSS2_SYS_CONTEXT *sapi_context,
+        TPMI_RH_NV_INDEX nv_index, TPM2B_NV_PUBLIC *nv_public) {
+
+    TPM2B_NAME nv_name = TPM2B_TYPE_INIT(TPM2B_NAME, name);
+
+    return Tss2_Sys_NV_ReadPublic(sapi_context, nv_index, 0, nv_public,
+            &nv_name, 0);
+}

--- a/lib/tpm2_nv_util.c
+++ b/lib/tpm2_nv_util.c
@@ -1,0 +1,312 @@
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <sapi/tpm20.h>
+
+#include "log.h"
+#include "tpm2_nv_util.h"
+#include "tpm2_util.h"
+
+#define xstr(s) str(s)
+#define str(s) #s
+
+#define dispatch_no_arg_add(x) \
+    { .name = str(x), .has_argument = false, .callback=x }
+
+#define dispatch_arg_add(x) \
+    { .name = str(x), .has_argument = true, .callback=x }
+
+typedef enum dispatch_error dispatch_error;
+enum dispatch_error {
+    dispatch_ok = 0,
+    dispatch_err,
+    dispatch_no_match,
+};
+
+typedef bool (*action)(TPMA_NV *nv, char *arg);
+
+typedef struct dispatch_table dispatch_table;
+struct dispatch_table {
+    char *name;
+    bool has_argument;
+    action callback;
+};
+
+static bool authread(TPMA_NV *nv, char *arg) {
+
+    (void) arg;
+    nv->TPMA_NV_AUTHREAD = 1;
+    return true;
+}
+
+static bool authwrite(TPMA_NV *nv, char *arg) {
+
+    (void) arg;
+    nv->TPMA_NV_AUTHWRITE = 1;
+    return true;
+}
+
+static bool clear_stclear(TPMA_NV *nv, char *arg) {
+
+    (void) arg;
+    nv->TPMA_NV_CLEAR_STCLEAR = 1;
+    return true;
+}
+
+static bool globallock(TPMA_NV *nv, char *arg) {
+
+    (void) arg;
+    nv->TPMA_NV_GLOBALLOCK = 1;
+    return true;
+}
+
+static bool no_da(TPMA_NV *nv, char *arg) {
+
+    (void) arg;
+    nv->TPMA_NV_NO_DA = 1;
+    return true;
+}
+
+static bool orderly(TPMA_NV *nv, char *arg) {
+
+    (void) arg;
+    nv->TPMA_NV_ORDERLY = 1;
+    return true;
+}
+
+static bool ownerread(TPMA_NV *nv, char *arg) {
+
+    (void) arg;
+    nv->TPMA_NV_OWNERREAD = 1;
+    return true;
+}
+
+static bool ownerwrite(TPMA_NV *nv, char *arg) {
+
+    (void) arg;
+    nv->TPMA_NV_OWNERWRITE = 1;
+    return true;
+}
+
+static bool platformcreate(TPMA_NV *nv, char *arg) {
+
+    (void) arg;
+    nv->TPMA_NV_PLATFORMCREATE = 1;
+    return true;
+}
+
+static bool policyread(TPMA_NV *nv, char *arg) {
+
+    (void) arg;
+    nv->TPMA_NV_POLICYREAD = 1;
+    return true;
+}
+
+static bool policywrite(TPMA_NV *nv, char *arg) {
+
+    (void) arg;
+    nv->TPMA_NV_POLICYWRITE = 1;
+    return true;
+}
+
+static bool policydelete(TPMA_NV *nv, char *arg) {
+
+    (void) arg;
+    nv->TPMA_NV_POLICY_DELETE = 1;
+    return true;
+}
+
+static bool ppread(TPMA_NV *nv, char *arg) {
+
+    (void) arg;
+    nv->TPMA_NV_PPREAD = 1;
+    return true;
+}
+
+static bool ppwrite(TPMA_NV *nv, char *arg) {
+
+    (void) arg;
+    nv->TPMA_NV_PPWRITE = 1;
+    return true;
+}
+
+static bool readlocked(TPMA_NV *nv, char *arg) {
+
+    (void) arg;
+    nv->TPMA_NV_READLOCKED = 1;
+    return true;
+}
+
+static bool read_stclear(TPMA_NV *nv, char *arg) {
+
+    (void) arg;
+    nv->TPMA_NV_READ_STCLEAR = 1;
+    return true;
+}
+
+static bool writeall(TPMA_NV *nv, char *arg) {
+
+    (void) arg;
+    nv->TPMA_NV_WRITEALL = 1;
+    return true;
+}
+
+static bool writedefine(TPMA_NV *nv, char *arg) {
+
+    (void) arg;
+    nv->TPMA_NV_WRITEDEFINE = 1;
+    return true;
+}
+
+static bool writelocked(TPMA_NV *nv, char *arg) {
+
+    (void) arg;
+    nv->TPMA_NV_WRITELOCKED = 1;
+    return true;
+}
+
+static bool write_stclear(TPMA_NV *nv, char *arg) {
+
+    (void) arg;
+    nv->TPMA_NV_WRITE_STCLEAR = 1;
+    return true;
+}
+
+static bool written(TPMA_NV *nv, char *arg) {
+
+    (void) arg;
+    nv->TPMA_NV_WRITTEN = 1;
+    return true;
+}
+
+static bool nt(TPMA_NV *nv, char *arg) {
+
+    uint16_t value;
+    bool result = tpm2_util_string_to_uint16(arg, &value);
+    if (!result) {
+        LOG_ERR("Could not convert \"%s\", to a number", arg);
+        return false;
+    }
+
+    /* nt space is 4 bits, so max of 15 */
+    if (value > 0x0F) {
+        LOG_ERR("Field TPM_NT of type TPMA_NV is only 4 bits,"
+                "value \"%s\" to big!", arg);
+        return false;
+    }
+
+    nv->TPM_NT = value;
+    return true;
+}
+
+static dispatch_table dtable[] = {
+    dispatch_no_arg_add(authread),
+    dispatch_no_arg_add(authwrite),
+    dispatch_no_arg_add(clear_stclear),
+    dispatch_no_arg_add(globallock),
+    dispatch_no_arg_add(no_da),
+    dispatch_no_arg_add(orderly),
+    dispatch_no_arg_add(ownerread),
+    dispatch_no_arg_add(ownerwrite),
+    dispatch_no_arg_add(platformcreate),
+    dispatch_no_arg_add(policyread),
+    dispatch_no_arg_add(policywrite),
+    dispatch_no_arg_add(policydelete),
+    dispatch_no_arg_add(ppread),
+    dispatch_no_arg_add(ppwrite),
+    dispatch_no_arg_add(readlocked),
+    dispatch_no_arg_add(read_stclear),
+    dispatch_no_arg_add(writeall),
+    dispatch_no_arg_add(writedefine),
+    dispatch_no_arg_add(writelocked),
+    dispatch_no_arg_add(write_stclear),
+    dispatch_no_arg_add(written),
+    dispatch_arg_add(nt)
+};
+
+static dispatch_error handle_dispatch(dispatch_table *d, char *token,
+        TPMA_NV *nvattrs) {
+
+    char *name = d->name;
+    action cb = d->callback;
+    bool has_arg = d->has_argument;
+
+    /*
+     * If it has an argument, split it on the equals sign if found.
+     */
+    char *arg = NULL;
+    if (has_arg) {
+        char *tmp = strchr(token, '=');
+        if (!tmp) {
+            LOG_ERR("Expected argument for \"%s\", got none.", token);
+            return dispatch_err;
+        }
+
+        /* split token on = */
+        *tmp = '\0';
+        tmp++;
+        if (!tmp) {
+            LOG_ERR("Expected argument for \"%s\", got none.", token);
+            return dispatch_err;
+        }
+
+        /* valid argument string, assign */
+        arg = tmp;
+    }
+
+    if (strcmp(name, token)) {
+        return dispatch_no_match;
+    }
+
+    bool result = cb(nvattrs, arg);
+    return result ? dispatch_ok : dispatch_err;
+}
+
+bool tpm2_nv_util_attrs_to_val(char *attribute_list, TPMA_NV *nvattrs) {
+
+    char *token;
+    char *save;
+
+    /*
+     * This check is soley to prevent GCC from complaining on:
+     * error: ‘attribute_list’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
+     * Might as well check nvattrs as well.
+     */
+    if (!attribute_list || !nvattrs) {
+        LOG_ERR("attribute listr or nvattrs is NULL");
+        return false;
+    }
+
+    while ((token = strtok_r(attribute_list, "|", &save))) {
+        attribute_list = NULL;
+
+        bool did_dispatch = false;
+
+        size_t i;
+        for (i = 0; i < ARRAY_LEN(dtable); i++) {
+            dispatch_table *d = &dtable[i];
+
+            dispatch_error err = handle_dispatch(d, token, nvattrs);
+            if (err == dispatch_ok) {
+                did_dispatch = true;
+                break;
+            } else if (err == dispatch_err) {
+                return false;
+            }
+            /* dispatch_no_match --> keep looking */
+        }
+
+        /* did we dispatch?, If not log error and return */
+        if (!did_dispatch) {
+            char *tmp = strchr(token, '=');
+            if (tmp) {
+                *tmp = '\0';
+            }
+            LOG_ERR("Unknown token: \"%s\" found.", token);
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/lib/tpm2_nv_util.h
+++ b/lib/tpm2_nv_util.h
@@ -1,0 +1,24 @@
+#ifndef LIB_TPM2_NV_UTIL_H_
+#define LIB_TPM2_NV_UTIL_H_
+
+#include <stdbool.h>
+
+#include <sapi/tpm20.h>
+
+/**
+ * Converts a list of | (pipe) separated attributes as defined in tavle 204
+ * of https://trustedcomputinggroup.org/wp-content/uploads/TPM-Rev-2.0-Part-2-Structures-01.38.pdf
+ * to an actual bit field representation. The trailing TPMA_NV_ can be omitted and must be lower-case.
+ * For exmaple, TPMA_NV_PPWRITE, bcomes ppwrite. To append them together, just do the pipe inbetwwen.
+ * ppwrite|ownerwrite.
+ *
+ * @param attribute_list
+ *  The attribute string to parse, which may be modified in place.
+ * @param nvattrs
+ *  The TPMA_NV attributes set based on the attribute list. Only valid on true returns.
+ * @return
+ *  true on success, false on error.
+ */
+bool tpm2_nv_util_attrs_to_val(char *attribute_list, TPMA_NV *nvattrs);
+
+#endif /* LIB_TPM2_NV_UTIL_H_ */

--- a/lib/tpm2_nv_util.h
+++ b/lib/tpm2_nv_util.h
@@ -21,4 +21,18 @@
  */
 bool tpm2_nv_util_attrs_to_val(char *attribute_list, TPMA_NV *nvattrs);
 
+/**
+ * Reads the public portion of a Non-Volatile (nv) index.
+ * @param sapi_context
+ *  The system API context.
+ * @param nv_index
+ *  The index to read.
+ * @param nv_public
+ *  The public data structure to store the results in.
+ * @return
+ *  The error code from the TPM. TPM_RC_SUCCESS on success.
+ */
+TPM_RC tpm2_util_nv_read_public(TSS2_SYS_CONTEXT *sapi_context,
+        TPMI_RH_NV_INDEX nv_index, TPM2B_NV_PUBLIC *nv_public);
+
 #endif /* LIB_TPM2_NV_UTIL_H_ */

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -6,6 +6,8 @@
 
 #include <sapi/tpm20.h>
 
+#define ARRAY_LEN(x) (sizeof(x)/sizeof(x[0]))
+
 #define BUFFER_SIZE(type, field) (sizeof((((type *)NULL)->t.field)))
 
 #define TPM2B_TYPE_INIT(type, field) { .t = { .size = BUFFER_SIZE(type, field), }, }

--- a/man/tpm2_nvdefine.8.in
+++ b/man/tpm2_nvdefine.8.in
@@ -30,7 +30,7 @@
 .SH NAME
 tpm2_nvdefine\ - Define NV index with given auth value, if passwd not given, assume NULL
 .SH SYNOPSIS
-.B tpm2_nvdefine[ COMMON OPTIONS ] [ TCTI OPTIONS ] [ \fB\-\-index\fR|\fB\-\-authHandle\fR|\fB\-\-size\fR|\fB\-\-attribute\fR|\fB\-\-handlePasswd\fR|\fB\-\-indexPasswd\fR|\fB\-\-passwdInHex\fR|\fB\fB\-\-policy-file\fR|\fB\-\-enforce\-read\-policy\fR|\fB\-\-enforce\-write\-policy\fR|\fB\-\-enforce\-delete\-policy\fR|\fB\-\-input-session-handle\fR|\fB ]
+.B tpm2_nvdefine[ COMMON OPTIONS ] [ TCTI OPTIONS ] [ \fB\-\-index\fR|\fB\-\-authHandle\fR|\fB\-\-size\fR|\fB\-\-attribute\fR|\fB\-\-handlePasswd\fR|\fB\-\-indexPasswd\fR|\fB\-\-passwdInHex\fR|\fB\fB\-\-policy-file\fR|\fB-\-input-session-handle\fR\fB ]
 .PP
 Define NV index with given auth value, if passwd not given, assume NULL
 .SH DESCRIPTION
@@ -48,7 +48,19 @@ specifies the handle used to authorize:  0x40000001 (TPM_RH_OWNER)   0x4000000C 
 specifies the size of data area.
 .TP
 \fB\-t ,\-\-attribute\fR
-specifies the value of attribute in  publicInfo struct (need calculate outside). 
+Specifies the attribute values for the nv region used when creating the entitiy. Either the raw
+bitfield mask or "nice-names" may be used. The values can be found in Table 204 Part 2 of the TPM2.0
+specification, which can be found here:
+.UR
+https://trustedcomputinggroup.org/wp-content/uploads/TPM-Rev-2.0-Part-2-Structures-01.38.pdf
+.UE.
+
+Nice names are calculated by taking the name field of table 204 and removing the prefix TPMA_NV_
+and lowercasing the result. Thus, TPMA_NV_PPWRITE becomes ppwrite. Nice names can be joined
+using the bitwise or "|" symbol. Note that the TPM_NT is 4 bits wide, and thus can be set via
+nt=<num> format. For instance, to set The fields TPMA_NV_OWNERREAD, TPMA_NV_OWNERWRITE,
+TPMA_NV_POLICYWRITE, and TPMA_NT = 0x3, the argument would be:
+ownerread|ownerwrite|policywrite|nt=0x3
 .TP
 \fB\-P ,\-\-handlePasswd\fR
 specifies the password of authHandle.
@@ -62,16 +74,6 @@ passwords given by any options are hex format
 \fB\-L ,\-\-policy\-file\fR
 Specifies the policy digest file for policy based authorizations.
 .TP
-\fB\-r ,\-\-enforce\-read\-policy\fR
-Enforce policy based authorization for reading the NV index
-.TP
-\fB\-w ,\-\-enforce\-write\-policy\fR
-Enforce policy based authorization for writing the NV index
-.TP
-\fB\-d ,\-\-enforce\-delete\-policy\fR
-Enforce policy based authorization for deleting the NV index. 
-Caution with using this option - If policy is not satisfied the index cannot be deleted.
-.TP
 \fB\-S ,\-\-input-session-handle\fR
 Optional Input session handle from a policy session for authorization.
 @COMMON_OPTIONS_INCLUDE@
@@ -83,6 +85,6 @@ Optional Input session handle from a policy session for authorization.
 .nf
 .RS
 tpm2_nvdefine -x 0x1500016 -a 0x40000001 -s 32 -t 0x2000A
-tpm2_nvdefine -x 0x1500016 -a 0x40000001 -s 32 -t 0x2000A -I 1a1b1c -X
+tpm2_nvdefine -x 0x1500016 -a 0x40000001 -s 32 -t ownerread|ownerwrite|policywrite -I 1a1b1c -X
 .RE
 .fi

--- a/test/system/test_tpm2_nv.sh
+++ b/test/system/test_tpm2_nv.sh
@@ -48,7 +48,7 @@ tpm2_nvrelease -x $nv_test_index -a $nv_auth_handle
  fi
 fi
 
-tpm2_nvdefine -x $nv_test_index -a $nv_auth_handle -s 32 -t 0x2000A  
+tpm2_nvdefine -x $nv_test_index -a $nv_auth_handle -s 32 -t "ownerread|policywrite|ownerwrite"
 if [ $? != 0 ];then 
  echo "nvdefine fail,Please check your environment!"
  exit 1
@@ -91,7 +91,7 @@ fi
 echo "f28230c080bbe417141199e36d18978228d8948fc10a6a24921b9eba6bb1d988" \
 | xxd -r -p > policy.bin
 
-tpm2_nvdefine -x 0x1500016 -a 0x40000001 -s 32 -t 0x2000A -L policy.bin -r -w
+tpm2_nvdefine -x 0x1500016 -a 0x40000001 -s 32 -t 0x2000A -L policy.bin -t "ownerread|ownerwrite|policywrite|policyread"
 if [ $? != 0 ];then
  echo "Failed tpm2_nvdefine"
  exit 1

--- a/test/system/test_tpm2_nv.sh
+++ b/test/system/test_tpm2_nv.sh
@@ -145,7 +145,7 @@ if [ $? != 0 ];then
   exit 1
 fi
 
-tpm2_nvread -x $nv_test_index -a $nv_auth_handle -s $large_file_size
+tpm2_nvread -x $nv_test_index -a $nv_auth_handle
 if [ $? != 0 ];then
   rm -f $large_file_name
   echo "nvread failed for testing large reads!"

--- a/test/system/test_tpm2_nv.sh
+++ b/test/system/test_tpm2_nv.sh
@@ -145,14 +145,23 @@ if [ $? != 0 ];then
   exit 1
 fi
 
-tpm2_nvread -x $nv_test_index -a $nv_auth_handle
+large_file_read_name="nv.test_large_w"
+tpm2_nvread -x $nv_test_index -a $nv_auth_handle | xxd -r > $large_file_read_name
 if [ $? != 0 ];then
   rm -f $large_file_name
+  rm -f $large_file_read_name
   echo "nvread failed for testing large reads!"
   exit 1
 fi
 
+cmp -s $large_file_read_name $large_file_name
+rm -f $large_file_read_name
 rm -f $large_file_name
+
+rc=$?
+if [ $rc != 0 ]; then
+  echo "Comparing the written and read large files failed with: $rc"
+fi
 
 tpm2_nvlist|grep -i $nv_test_index
 if [ $? != 0 ];then

--- a/test/system/test_tpm2_nv.sh
+++ b/test/system/test_tpm2_nv.sh
@@ -145,10 +145,12 @@ if [ $? != 0 ];then
   exit 1
 fi
 
-#
-# TODO: Reading large files is currently broken, add a test and ensure the written matches
-# the read.
-#
+tpm2_nvread -x $nv_test_index -a $nv_auth_handle -s $large_file_size
+if [ $? != 0 ];then
+  rm -f $large_file_name
+  echo "nvread failed for testing large reads!"
+  exit 1
+fi
 
 rm -f $large_file_name
 

--- a/test/unit/test_tpm2_nv_util.c
+++ b/test/unit/test_tpm2_nv_util.c
@@ -1,0 +1,205 @@
+//**********************************************************************;
+// Copyright (c) 2016, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <setjmp.h>
+
+#include <cmocka.h>
+#include <sapi/tpm20.h>
+
+#include "tpm2_nv_util.h"
+
+/*
+ assert_true(nvattrs.x); \
+    \
+        assert_true(nvattrs.val = TPMA_NV_##x); \
+*/
+
+#define single_test_get(set) \
+    test_tpm2_nv_util_attrs_to_val_##set
+
+#define single_item_test(argstr, set) \
+    static void test_tpm2_nv_util_attrs_to_val_##set(void **state) { \
+        \
+        (void)state; \
+    \
+        TPMA_NV nvattrs = { \
+            .val = 0, \
+        }; \
+        /* make mutable strings for strtok_r */ \
+        char arg[] = argstr; \
+        bool res = tpm2_nv_util_attrs_to_val(arg, &nvattrs); \
+        assert_true(res); \
+        assert_true(nvattrs.set); \
+        assert_true(nvattrs.val == TPMA_NV_##set); \
+    }
+
+single_item_test("authread", TPMA_NV_AUTHREAD);
+single_item_test("authwrite", TPMA_NV_AUTHWRITE);
+single_item_test("clear_stclear", TPMA_NV_CLEAR_STCLEAR);
+single_item_test("globallock", TPMA_NV_GLOBALLOCK);
+single_item_test("no_da", TPMA_NV_NO_DA);
+single_item_test("orderly", TPMA_NV_ORDERLY);
+single_item_test("ownerread", TPMA_NV_OWNERREAD);
+single_item_test("ownerwrite", TPMA_NV_OWNERWRITE);
+single_item_test("platformcreate", TPMA_NV_PLATFORMCREATE);
+single_item_test("policyread", TPMA_NV_POLICYREAD);
+single_item_test("policywrite", TPMA_NV_POLICYWRITE);
+single_item_test("policydelete", TPMA_NV_POLICY_DELETE);
+single_item_test("ppread", TPMA_NV_PPREAD);
+single_item_test("ppwrite", TPMA_NV_PPWRITE);
+single_item_test("readlocked", TPMA_NV_READLOCKED);
+single_item_test("read_stclear", TPMA_NV_READ_STCLEAR);
+single_item_test("writeall", TPMA_NV_WRITEALL);
+single_item_test("writedefine", TPMA_NV_WRITEDEFINE);
+single_item_test("writelocked", TPMA_NV_WRITELOCKED);
+single_item_test("write_stclear", TPMA_NV_WRITE_STCLEAR);
+single_item_test("written", TPMA_NV_WRITTEN);
+
+static void test_tpm2_nv_util_attrs_to_val_nt_good(void **state) {
+    (void) state;
+
+    TPMA_NV nvattrs = { .val = 0, };
+
+    char arg[] = "nt=0x1";
+    bool res = tpm2_nv_util_attrs_to_val(arg, &nvattrs);
+    assert_true(res);
+    assert_true(nvattrs.TPM_NT == 0x1);
+}
+
+static void test_tpm2_nv_util_attrs_to_val_nt_bad(void **state) {
+    (void) state;
+
+    TPMA_NV nvattrs = { .val = 0, };
+
+    char arg[] = "nt=16";
+    bool res = tpm2_nv_util_attrs_to_val(arg, &nvattrs);
+    assert_false(res);
+}
+
+static void test_tpm2_nv_util_attrs_to_val_nt_malformed(void **state) {
+    (void) state;
+
+    TPMA_NV nvattrs = { .val = 0, };
+
+    char arg[] = "nt=";
+    bool res = tpm2_nv_util_attrs_to_val(arg, &nvattrs);
+    assert_false(res);
+
+    char arg1[] = "nt";
+    res = tpm2_nv_util_attrs_to_val(arg1, &nvattrs);
+    assert_false(res);
+}
+
+static void test_tpm2_nv_util_attrs_to_val_option_no_option(void **state) {
+    (void) state;
+
+    TPMA_NV nvattrs = { .val = 0, };
+
+    char arg[] = "authread=";
+    bool res = tpm2_nv_util_attrs_to_val(arg, &nvattrs);
+    assert_false(res);
+
+    char arg1[] = "authread=0x1";
+    res = tpm2_nv_util_attrs_to_val(arg1, &nvattrs);
+    assert_false(res);
+}
+
+static void test_tpm2_nv_util_attrs_to_val_multiple_good(void **state) {
+    (void) state;
+
+    TPMA_NV nvattrs = { .val = 0, };
+
+    char arg[] = "authread|authwrite|nt=0x4";
+    bool res = tpm2_nv_util_attrs_to_val(arg, &nvattrs);
+    assert_true(res);
+    assert_true(nvattrs.TPM_NT == 0x4);
+    assert_true(nvattrs.TPMA_NV_AUTHREAD);
+    assert_true(nvattrs.TPMA_NV_AUTHWRITE);
+}
+
+static void test_tpm2_nv_util_attrs_to_val_token_unknown(void **state) {
+    (void) state;
+
+    TPMA_NV nvattrs = { .val = 0, };
+
+    char arg[] = "authread|authfoo|nt=0x4";
+    bool res = tpm2_nv_util_attrs_to_val(arg, &nvattrs);
+    assert_false(res);
+
+    char arg1[] = "foo";
+    res = tpm2_nv_util_attrs_to_val(arg1, &nvattrs);
+    assert_false(res);
+
+    char arg2[] = "foo=";
+    res = tpm2_nv_util_attrs_to_val(arg2, &nvattrs);
+    assert_false(res);
+
+    /* should be interprested as the whole thing, no = */
+    char arg3[] = "nt:0x4";
+    res = tpm2_nv_util_attrs_to_val(arg3, &nvattrs);
+    assert_false(res);
+}
+
+//        dispatch_arg_add(nt),
+
+int main(int argc, char* argv[]) {
+    (void) argc;
+    (void) argv;
+
+    const struct CMUnitTest tests[] = { cmocka_unit_test(
+            single_test_get(TPMA_NV_AUTHREAD)), cmocka_unit_test(
+            single_test_get(TPMA_NV_AUTHWRITE)), cmocka_unit_test(
+            single_test_get(TPMA_NV_CLEAR_STCLEAR)), cmocka_unit_test(
+            single_test_get(TPMA_NV_GLOBALLOCK)), cmocka_unit_test(
+            single_test_get(TPMA_NV_NO_DA)), cmocka_unit_test(
+            single_test_get(TPMA_NV_ORDERLY)), cmocka_unit_test(
+            single_test_get(TPMA_NV_OWNERREAD)), cmocka_unit_test(
+            single_test_get(TPMA_NV_OWNERWRITE)), cmocka_unit_test(
+            single_test_get(TPMA_NV_PLATFORMCREATE)), cmocka_unit_test(
+            single_test_get(TPMA_NV_POLICYREAD)), cmocka_unit_test(
+            single_test_get(TPMA_NV_POLICYWRITE)), cmocka_unit_test(
+            single_test_get(TPMA_NV_POLICY_DELETE)), cmocka_unit_test(
+            single_test_get(TPMA_NV_PPREAD)), cmocka_unit_test(
+            single_test_get(TPMA_NV_PPWRITE)), cmocka_unit_test(
+            single_test_get(TPMA_NV_READLOCKED)), cmocka_unit_test(
+            single_test_get(TPMA_NV_READ_STCLEAR)), cmocka_unit_test(
+            single_test_get(TPMA_NV_WRITEALL)), cmocka_unit_test(
+            single_test_get(TPMA_NV_WRITEDEFINE)), cmocka_unit_test(
+            single_test_get(TPMA_NV_WRITELOCKED)), cmocka_unit_test(
+            single_test_get(TPMA_NV_WRITE_STCLEAR)), cmocka_unit_test(
+            single_test_get(TPMA_NV_WRITTEN)), cmocka_unit_test(
+            test_tpm2_nv_util_attrs_to_val_nt_good), cmocka_unit_test(
+            test_tpm2_nv_util_attrs_to_val_nt_bad), cmocka_unit_test(
+            test_tpm2_nv_util_attrs_to_val_nt_malformed), cmocka_unit_test(
+            test_tpm2_nv_util_attrs_to_val_multiple_good), cmocka_unit_test(
+            test_tpm2_nv_util_attrs_to_val_option_no_option), cmocka_unit_test(
+            test_tpm2_nv_util_attrs_to_val_token_unknown), };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -61,8 +61,6 @@ struct tpm_certify_ctx {
     TSS2_SYS_CONTEXT *sapi_context;
 };
 
-#define ARRAY_LEN(x) (sizeof(x)/sizeof(x[0]))
-
 static bool get_key_type(TSS2_SYS_CONTEXT *sapi_context, TPMI_DH_OBJECT object_handle, TPMI_ALG_PUBLIC *type) {
 
     TPMS_AUTH_RESPONSE session_data_out;

--- a/tools/tpm2_nvread.c
+++ b/tools/tpm2_nvread.c
@@ -100,6 +100,11 @@ static bool nv_read(tpm_nvread_ctx *ctx) {
 
     UINT16 data_size = nv_public.t.nvPublic.dataSize;
 
+    /* if no size was specified, assume the whole object */
+    if (ctx->size_to_read == 0) {
+        ctx->size_to_read = data_size;
+    }
+
     if (ctx->offset > data_size) {
         LOG_ERR(
             "Requested offset to read from is greater than size. offset=%u"

--- a/tools/tpm2_nvwrite.c
+++ b/tools/tpm2_nvwrite.c
@@ -93,6 +93,7 @@ static int nv_write(tpm_nvwrite_ctx *ctx) {
         return false;
     }
 
+    UINT16 offset = 0;
     while (ctx->data_size > 0) {
 
         nv_write_data.t.size =
@@ -102,7 +103,6 @@ static int nv_write(tpm_nvwrite_ctx *ctx) {
         LOG_INFO("The data(size=%d) to be written:\n", nv_write_data.t.size);
 
         UINT16 i;
-        UINT16 offset = 0;
         for (i = 0; i < nv_write_data.t.size; i++) {
             nv_write_data.t.buffer[i] = ctx->nv_buffer[offset + i];
             printf("%02x ", ctx->nv_buffer[offset + i]);

--- a/tools/tpm2_readpublic.c
+++ b/tools/tpm2_readpublic.c
@@ -52,8 +52,6 @@ struct tpm_readpub_ctx {
     TSS2_SYS_CONTEXT *sapi_context;
 };
 
-#define ARRAY_LEN(x) (sizeof(x)/sizeof(x[0]))
-
 static int read_public_and_save(tpm_readpub_ctx *ctx) {
 
     TPMS_AUTH_RESPONSE session_out_data;

--- a/tools/tpm2_takeownership.c
+++ b/tools/tpm2_takeownership.c
@@ -93,8 +93,6 @@ bool clear_hierarchy_auth(takeownership_ctx *ctx) {
     return true;
 }
 
-#define ARRAY_LEN(x) (sizeof(x)/sizeof(*x))
-
 static bool change_hierarchy_auth(takeownership_ctx *ctx) {
 
     TPM2B_AUTH newAuth;


### PR DESCRIPTION
This replaces PR #359 and adds to it.

This starts to get rid of specifying the attributes for nv indexes during nvdefine in raw numerical format.
I still need to modify tom2_nvdefine to use it, and update it's man page.

- Unit tests are in place for the new attribute keyword parser.
- System test is in place for writing a big nvindex.
- System tests in place for using nice names.
- System tests in place for verifying that nvread reads the same bytes as nvwrite.
- nvread output is in xxd -r compatible format.
- nvread -s is no longer needed.