### PR TITLE
Refactor build_policy() and reuse it from tpm2_unseal tool (and also fix issue #364)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -93,6 +93,7 @@ lib_libcommon_a_SOURCES = \
     lib/tpm_hmac.c \
     lib/tpm_kdfa.c \
     lib/tpm_session.c \
+    lib/tpm2_policy.c \
     lib/tpm2_util.c \
     lib/tpm2_nv_util.c
 

--- a/lib/tpm2_policy.c
+++ b/lib/tpm2_policy.c
@@ -1,0 +1,235 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <errno.h>
+
+#include "files.h"
+#include "log.h"
+#include "tpm2_policy.h"
+
+static unsigned get_size_from_alg(TPMI_ALG_HASH hashAlg) {
+    switch (hashAlg) {
+        case TPM_ALG_SHA1:
+            return SHA1_DIGEST_SIZE;
+        case TPM_ALG_SHA256:
+            return SHA256_DIGEST_SIZE;
+        case TPM_ALG_SHA384:
+            return SHA384_DIGEST_SIZE;
+        case TPM_ALG_SHA512:
+            return SHA512_DIGEST_SIZE;
+        case TPM_ALG_SM3_256:
+            return SM3_256_DIGEST_SIZE;
+        default:
+            LOG_ERR("Unknown hashAlg, cannot determine digest size.\n");
+            return 0;
+    }
+}
+
+static bool evaluate_populate_pcr_digests(TPML_PCR_SELECTION pcr_selections,
+                                          char *raw_pcrs_file,
+                                          TPML_DIGEST *pcr_values) {
+    //octet value of a pcr selection group
+    uint8_t group_val=0;
+    //total pcr indices per algorithm/ bank. Typically this is 24
+    uint8_t total_indices_for_this_alg=0;
+    //cumulative size total of selected indices per hashAlg
+    unsigned expected_pcr_input_file_size=0;
+    //loop counters
+    unsigned i, j, k, dgst_cnt=0;
+    const uint8_t bits_per_nibble[] = {0,1,1,2,1,2,2,3,1,2,2,3,2,3,3,4};
+
+    //Iterating the number of pcr banks selected
+    for (i=0; i < pcr_selections.count; i++) {
+        //Looping to check total pcr select bits in the pcr-select-octets for a bank
+        for (j=0; j < pcr_selections.pcrSelections[i].sizeofSelect; j++) {
+            group_val = pcr_selections.pcrSelections[i].pcrSelect[j];
+            total_indices_for_this_alg += bits_per_nibble[group_val & 0x0f];
+            total_indices_for_this_alg += bits_per_nibble[group_val >> 4];
+        }
+
+        //digest size returned per the hashAlg type
+        unsigned dgst_size = get_size_from_alg(pcr_selections.pcrSelections[i].hash);
+        if (!dgst_size) {
+            return false;
+        }
+        expected_pcr_input_file_size += (total_indices_for_this_alg * dgst_size);
+
+        //Cumulative total of all the pcr indices across banks selected in setlist
+        pcr_values->count += total_indices_for_this_alg;
+
+        /*
+         * Populating the digest sizes in the PCR digest list per algorithm bank
+         * Once iterated through all banks, creates an file offsets map for all pcr indices
+         */
+        for (k=0; k < total_indices_for_this_alg; k++) {
+            pcr_values->digests[dgst_cnt+k].t.size = dgst_size;
+        }
+        dgst_cnt++;
+
+        total_indices_for_this_alg=0;
+    }
+
+    //Check if the input pcrs file size is the same size as the pcr selection setlist
+    if (raw_pcrs_file) {
+        unsigned long filesize = 0;
+        bool result = files_get_file_size(raw_pcrs_file, &filesize);
+        if (!result) {
+            LOG_ERR("Could not retrieve raw_pcrs_file size\n");
+            return false;
+        }
+        if (filesize != expected_pcr_input_file_size) {
+            LOG_ERR("pcr-input-file filesize does not match pcr set-list");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+TPM_RC tpm2_policy_pcr_build(TSS2_SYS_CONTEXT *sapi_context,
+                             SESSION *policy_session,
+                             TPML_PCR_SELECTION pcr_selections,
+                             char *raw_pcrs_file) {
+    // Calculate digest( with authhash alg) of pcrvalues in variable pcr_digest
+    TPM_RC rval=0;
+    TPML_DIGEST pcr_values = {
+        .count = 0
+    };
+
+    bool result = evaluate_populate_pcr_digests(pcr_selections, raw_pcrs_file,
+                                                &pcr_values);
+    if (!result) {
+        return TPM_RC_NO_RESULT;
+    }
+
+    //If PCR input for policy is from raw pcrs file
+    if (raw_pcrs_file) {
+        FILE *fp = fopen (raw_pcrs_file, "rb");
+        if (fp == NULL) {
+            LOG_ERR("Cannot open pcr-input-file %s", raw_pcrs_file);
+            return TPM_RC_NO_RESULT;
+        }
+       // Bank hashAlg values dictates the order of the list of digests
+        unsigned i;
+        for(i=0; i<pcr_values.count; i++) {
+            size_t sz = fread(&pcr_values.digests[i].t.buffer, 1, pcr_values.digests[i].t.size, fp);
+            if (sz != pcr_values.digests[i].t.size) {
+                const char *msg = ferror(fp) ? strerror(errno) :
+                        "end of file reached";
+                LOG_ERR("Reading from file \"%s\" failed: %s",
+                        raw_pcrs_file, msg);
+                fclose(fp);
+                return TPM_RC_NO_RESULT;
+            }
+        }
+        fclose(fp);
+    }
+
+    //If PCR input for policy is to be read from the TPM
+    if (!raw_pcrs_file) {
+        UINT32 pcr_update_counter;
+        TPML_PCR_SELECTION pcr_selection_out;
+        // Read PCRs
+        rval = Tss2_Sys_PCR_Read(sapi_context, 0,
+            &pcr_selections,
+            &pcr_update_counter, &pcr_selection_out, &pcr_values, 0);
+        if (rval != TPM_RC_SUCCESS) {
+            return rval;
+        }
+    }
+
+    // Calculate hashes
+    TPM2B_DIGEST pcr_digest =  TPM2B_TYPE_INIT(TPM2B_DIGEST, buffer);
+    rval = tpm_hash_sequence(sapi_context,
+        policy_session->authHash, pcr_values.count,
+        &pcr_values.digests[0], &pcr_digest);
+    if (rval != TPM_RC_SUCCESS) {
+        return rval;
+    }
+
+    // Call the PolicyPCR command
+    return Tss2_Sys_PolicyPCR(sapi_context, policy_session->sessionHandle,
+                              0, &pcr_digest, &pcr_selections, 0);
+}
+
+static TPM_RC start_policy_session (TSS2_SYS_CONTEXT *sapi_context,
+                                    SESSION **policy_session,
+                                    TPM_SE policy_session_type,
+                                    TPMI_ALG_HASH policy_digest_hash_alg) {
+    TPM2B_ENCRYPTED_SECRET encryptedSalt = TPM2B_EMPTY_INIT;
+    TPMT_SYM_DEF symmetric = {
+        .algorithm = TPM_ALG_NULL,
+    };
+    TPM2B_NONCE nonceCaller = TPM2B_EMPTY_INIT;
+    // Start policy session.
+    TPM_RC rval = tpm_session_start_auth_with_params(sapi_context,
+                                                     policy_session,
+                                                     TPM_RH_NULL, 0,
+                                                     TPM_RH_NULL, 0,
+                                                     &nonceCaller,
+                                                     &encryptedSalt,
+                                                     policy_session_type,
+                                                     &symmetric,
+                                                     policy_digest_hash_alg);
+    if (rval != TPM_RC_SUCCESS) {
+        LOG_ERR("Failed tpm session start auth with params\n");
+    }
+    return rval;
+}
+
+TPM_RC tpm2_policy_build(TSS2_SYS_CONTEXT *sapi_context,
+                         SESSION **policy_session,
+                         TPM_SE policy_session_type,
+                         TPMI_ALG_HASH policy_digest_hash_alg,
+                         TPML_PCR_SELECTION pcr_selections,
+                         char *raw_pcrs_file,
+                         TPM2B_DIGEST *policy_digest,
+                         bool extend_policy_session,
+        TPM_RC (*build_policy_function)(TSS2_SYS_CONTEXT *sapi_context,
+                                        SESSION *policy_session,
+                                        TPML_PCR_SELECTION pcr_selections,
+                                        char *raw_pcrs_file)) {
+    //Start policy session
+    TPM_RC rval = start_policy_session(sapi_context, policy_session,
+                                       policy_session_type,
+                                       policy_digest_hash_alg);
+    if (rval != TPM_RC_SUCCESS) {
+        LOG_ERR("Error starting the policy session.\n");
+        return rval;
+    }
+    // Issue policy command.
+    rval = (*build_policy_function)(sapi_context, *policy_session,
+                                    pcr_selections, raw_pcrs_file);
+    if (rval != TPM_RC_SUCCESS) {
+        LOG_ERR("Failed parse_policy_type_and_send_command\n");
+        return rval;
+    }
+    // Get Policy Hash
+    rval = Tss2_Sys_PolicyGetDigest(sapi_context,
+                                    (*policy_session)->sessionHandle,
+                                    0, policy_digest, 0);
+    if (rval != TPM_RC_SUCCESS) {
+        LOG_ERR("Failed Policy Get Digest\n");
+        return rval;
+    }
+
+    // Need to flush the session here.
+    if (!extend_policy_session) {
+        rval = Tss2_Sys_FlushContext(sapi_context,
+                                     (*policy_session)->sessionHandle);
+        if (rval != TPM_RC_SUCCESS) {
+            LOG_ERR("Failed Flush Context\n");
+            return rval;
+        }
+
+        // And remove the session from sessions table.
+        rval = tpm_session_auth_end(*policy_session);
+        if (rval != TPM_RC_SUCCESS) {
+            LOG_ERR("Failed deleting session from session table\n");
+            return rval;
+        }
+    }
+
+    return rval;
+}

--- a/lib/tpm2_policy.h
+++ b/lib/tpm2_policy.h
@@ -1,0 +1,28 @@
+#ifndef SRC_POLICY_H_
+#define SRC_POLICY_H_
+
+#include <sapi/tpm20.h>
+#include <stdbool.h>
+
+#include "tpm2_util.h"
+#include "tpm_hash.h"
+#include "tpm_session.h"
+
+TPM_RC tpm2_policy_pcr_build(TSS2_SYS_CONTEXT *sapi_context,
+                             SESSION *policy_session,
+                             TPML_PCR_SELECTION pcr_selections,
+                             char *raw_pcrs_file);
+TPM_RC tpm2_policy_build(TSS2_SYS_CONTEXT *sapi_context,
+                         SESSION **policy_session,
+                         TPM_SE policy_session_type,
+                         TPMI_ALG_HASH policy_digest_hash_alg,
+                         TPML_PCR_SELECTION pcr_selections,
+                         char *raw_pcrs_file,
+                         TPM2B_DIGEST *policy_digest,
+                         bool extend_policy_session,
+        TPM_RC (*build_policy_function)(TSS2_SYS_CONTEXT *sapi_context,
+                                        SESSION *policy_session,
+                                        TPML_PCR_SELECTION pcr_selections,
+                                        char *raw_pcrs_file));
+
+#endif /* SRC_POLICY_H_ */

--- a/test/system/test_tpm2_unseal.sh
+++ b/test/system/test_tpm2_unseal.sh
@@ -36,7 +36,7 @@ alg_create_obj=0x000B
 alg_create_key=0x0008
 alg_pcr_policy=0x0004
 
-pcr_index=0
+pcr_ids="0,1,2,3"
 
 obj_attr=0x492 # fixedTPM, fixedParent, adminWithPolicy, noDA
 
@@ -94,13 +94,13 @@ fi
 
 rm $file_unseal_key_pub $file_unseal_key_priv $file_unseal_key_name
 
-tpm2_listpcrs -L ${alg_pcr_policy}:${pcr_index} -o $file_pcr_value
+tpm2_listpcrs -L ${alg_pcr_policy}:${pcr_ids} -o $file_pcr_value
 if [ $? != 0 ];then
     echo "create raw pcr output fail, please check the environment or parameters!"
     exit 1
 fi
 
-tpm2_createpolicy -P -L ${alg_pcr_policy}:${pcr_index} -F $file_pcr_value -f $file_policy
+tpm2_createpolicy -P -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value -f $file_policy
 if [ $? != 0 ];then
     echo "create policy fail, please check the environment or parameters!"
     exit 1
@@ -118,7 +118,7 @@ if [ $? != 0 ];then
     exit 1
 fi
 
-unsealed=`tpm2_unseal -c $file_unseal_key_ctx -L ${alg_pcr_policy}:${pcr_index} -F $file_pcr_value`
+unsealed=`tpm2_unseal -c $file_unseal_key_ctx -L ${alg_pcr_policy}:${pcr_ids} -F $file_pcr_value`
 if [ $? != 0 ];then
     echo "unseal fail, please check the environment or parameters!"
     exit 1

--- a/tools/tpm2_createpolicy.c
+++ b/tools/tpm2_createpolicy.c
@@ -267,28 +267,7 @@ static TPM_RC build_policy(create_policy_ctx *pctx,
         LOG_ERR("Failed Policy Get Digest\n");
         return rval;
     }
-    // Display the policy digest during real policy session.
-    if (pctx->common_policy_options.policy_session_type == TPM_SE_POLICY) {
-        printf("TPM_SE_POLICY: 0x");
-        int i;
-        for(i=0; i<pctx->common_policy_options.policy_digest.t.size; i++) {
-            printf("%02X", pctx->common_policy_options.policy_digest.t.buffer[i]);
-        }
-        printf("\n");
-    }
-    // Additional operations when session if a trial policy session
-    if (pctx->common_policy_options.policy_session_type == TPM_SE_TRIAL) {
-        //save the policy buffer in a file for use later
-        bool result = files_save_bytes_to_file(pctx->common_policy_options.policy_file,
-            (UINT8 *) &pctx->common_policy_options.policy_digest.t.buffer,
-            pctx->common_policy_options.policy_digest.t.size);
-        if (!result) {
-            LOG_ERR("Failed to save policy digest into file \"%s\"",
-                    pctx->common_policy_options.policy_file);
-            rval = TPM_RC_NO_RESULT;
-            return rval;
-        }
-    }
+
     // Need to flush the session here.
     if (!pctx->common_policy_options.extend_policy_session) {
         rval = Tss2_Sys_FlushContext(pctx->sapi_context,
@@ -326,6 +305,30 @@ static TPM_RC parse_policy_type_specific_command (create_policy_ctx *pctx) {
         rval = build_policy(pctx, build_pcr_policy);
         if (rval != TPM_RC_SUCCESS) {
             goto parse_policy_type_specific_command_error;
+        }
+
+        // Display the policy digest during real policy session.
+        if (pctx->common_policy_options.policy_session_type == TPM_SE_POLICY) {
+            printf("TPM_SE_POLICY: 0x");
+            int i;
+            for(i = 0; i < pctx->common_policy_options.policy_digest.t.size; i++) {
+                printf("%02X", pctx->common_policy_options.policy_digest.t.buffer[i]);
+            }
+            printf("\n");
+        }
+
+        // Additional operations when session if a trial policy session
+        if (pctx->common_policy_options.policy_session_type == TPM_SE_TRIAL) {
+            //save the policy buffer in a file for use later
+            bool result = files_save_bytes_to_file(pctx->common_policy_options.policy_file,
+                              (UINT8 *) &pctx->common_policy_options.policy_digest.t.buffer,
+                                          pctx->common_policy_options.policy_digest.t.size);
+            if (!result) {
+                LOG_ERR("Failed to save policy digest into file \"%s\"",
+                        pctx->common_policy_options.policy_file);
+                rval = TPM_RC_NO_RESULT;
+                return rval;
+            }
         }
     }
 

--- a/tools/tpm2_createpolicy.c
+++ b/tools/tpm2_createpolicy.c
@@ -232,18 +232,25 @@ static TPM_RC build_pcr_policy(TSS2_SYS_CONTEXT *sapi_context,
                               0, &pcr_digest, &pcr_selections, 0);
 }
 
-static TPM_RC start_policy_session (create_policy_ctx *pctx) {
+static TPM_RC start_policy_session (TSS2_SYS_CONTEXT *sapi_context,
+                                    SESSION **policy_session,
+                                    TPM_SE policy_session_type,
+                                    TPMI_ALG_HASH policy_digest_hash_alg) {
     TPM2B_ENCRYPTED_SECRET encryptedSalt = TPM2B_EMPTY_INIT;
     TPMT_SYM_DEF symmetric = {
         .algorithm = TPM_ALG_NULL,
     };
     TPM2B_NONCE nonceCaller = TPM2B_EMPTY_INIT;
     // Start policy session.
-    TPM_RC rval = tpm_session_start_auth_with_params(pctx->sapi_context,
-            &pctx->common_policy_options.policy_session, TPM_RH_NULL, 0,
-            TPM_RH_NULL, 0, &nonceCaller, &encryptedSalt,
-            pctx->common_policy_options.policy_session_type, &symmetric,
-            pctx->common_policy_options.policy_digest_hash_alg);
+    TPM_RC rval = tpm_session_start_auth_with_params(sapi_context,
+                                                     policy_session,
+                                                     TPM_RH_NULL, 0,
+                                                     TPM_RH_NULL, 0,
+                                                     &nonceCaller,
+                                                     &encryptedSalt,
+                                                     policy_session_type,
+                                                     &symmetric,
+                                                     policy_digest_hash_alg);
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("Failed tpm session start auth with params\n");
     }
@@ -256,7 +263,10 @@ static TPM_RC build_policy(create_policy_ctx *pctx,
                                         TPML_PCR_SELECTION pcr_selections,
                                         char *raw_pcrs_file)) {
     //Start policy session
-    TPM_RC rval = start_policy_session(pctx);
+    TPM_RC rval = start_policy_session(pctx->sapi_context,
+                                       &pctx->common_policy_options.policy_session,
+                                       pctx->common_policy_options.policy_session_type,
+                                       pctx->common_policy_options.policy_digest_hash_alg);
     if (rval != TPM_RC_SUCCESS) {
         LOG_ERR("Error starting the policy session.\n");
         return rval;

--- a/tools/tpm2_createpolicy.c
+++ b/tools/tpm2_createpolicy.c
@@ -71,7 +71,6 @@ struct tpm2_pcr_policy_options{
     char *raw_pcrs_file; // filepath of input raw pcrs file
     TPML_PCR_SELECTION pcr_selections; // records user pcr selection per setlist
     bool is_set_list; // if user has provided the setlist choice
-    bool is_raw_pcrs_file; // if user has provided a raw pcrs file for policy calc
 };
 
 typedef struct create_policy_ctx create_policy_ctx;
@@ -149,7 +148,7 @@ static bool evaluate_populate_pcr_digests(create_policy_ctx *pctx, TPML_DIGEST *
     }
 
     //Check if the input pcrs file size is the same size as the pcr selection setlist
-    if (pctx->pcr_policy_options.is_raw_pcrs_file) {
+    if (pctx->pcr_policy_options.raw_pcrs_file) {
         unsigned long filesize = 0;
         bool result = files_get_file_size(pctx->pcr_policy_options.raw_pcrs_file, &filesize);
         if (!result) {
@@ -178,7 +177,7 @@ static TPM_RC build_pcr_policy(create_policy_ctx *pctx) {
     }
 
     //If PCR input for policy is from raw pcrs file
-    if (pctx->pcr_policy_options.is_raw_pcrs_file) {
+    if (pctx->pcr_policy_options.raw_pcrs_file) {
         FILE *fp = fopen (pctx->pcr_policy_options.raw_pcrs_file, "rb");
         if (fp == NULL) {
             LOG_ERR("Cannot open pcr-input-file %s", pctx->pcr_policy_options.raw_pcrs_file);
@@ -201,7 +200,7 @@ static TPM_RC build_pcr_policy(create_policy_ctx *pctx) {
     }
 
     //If PCR input for policy is to be read from the TPM
-    if (!pctx->pcr_policy_options.is_raw_pcrs_file) {
+    if (!pctx->pcr_policy_options.raw_pcrs_file) {
         UINT32 pcr_update_counter;
         TPML_PCR_SELECTION pcr_selection_out;
         // Read PCRs
@@ -363,7 +362,6 @@ static bool init(int argc, char *argv[], create_policy_ctx *pctx) {
             pctx->common_policy_options.policy_file = optarg;
             break;
         case 'F':
-            pctx->pcr_policy_options.is_raw_pcrs_file = true;
             pctx->pcr_policy_options.raw_pcrs_file = optarg;
             break;
         case 'g':

--- a/tools/tpm2_createpolicy.c
+++ b/tools/tpm2_createpolicy.c
@@ -298,12 +298,13 @@ static TPM_RC build_policy(create_policy_ctx *pctx,
             LOG_ERR("Failed Flush Context\n");
             return rval;
         }
-    }
-    // And remove the session from sessions table.
-    rval = tpm_session_auth_end(pctx->common_policy_options.policy_session);
-    if (rval != TPM_RC_SUCCESS) {
-        LOG_ERR("Failed deleting session from session table\n");
-        return rval;
+
+        // And remove the session from sessions table.
+        rval = tpm_session_auth_end(pctx->common_policy_options.policy_session);
+        if (rval != TPM_RC_SUCCESS) {
+            LOG_ERR("Failed deleting session from session table\n");
+            return rval;
+        }
     }
 
     return rval;

--- a/tools/tpm2_createpolicy.c
+++ b/tools/tpm2_createpolicy.c
@@ -28,7 +28,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 //**********************************************************************;
-#include <errno.h>
 #include <limits.h>
 #include <string.h>
 #include <stdio.h>
@@ -42,9 +41,7 @@
 #include "main.h"
 #include "options.h"
 #include "pcr.h"
-#include "tpm2_util.h"
-#include "tpm_session.h"
-#include "tpm_hash.h"
+#include "tpm2_policy.h"
 
 //Records the type of policy and if one is selected
 typedef struct {
@@ -87,234 +84,6 @@ struct create_policy_ctx {
             .policy_digest_hash_alg = TPM_ALG_SHA256, \
         }
 
-static unsigned get_size_from_alg(TPMI_ALG_HASH hashAlg) {
-    switch (hashAlg) {
-        case TPM_ALG_SHA1:
-            return SHA1_DIGEST_SIZE;
-        case TPM_ALG_SHA256:
-            return SHA256_DIGEST_SIZE;
-        case TPM_ALG_SHA384:
-            return SHA384_DIGEST_SIZE;
-        case TPM_ALG_SHA512:
-            return SHA512_DIGEST_SIZE;
-        case TPM_ALG_SM3_256:
-            return SM3_256_DIGEST_SIZE;
-        default:
-            LOG_ERR("Unknown hashAlg, cannot determine digest size.\n");
-            return 0;
-    }
-}
-
-static bool evaluate_populate_pcr_digests(TPML_PCR_SELECTION pcr_selections,
-                                          char *raw_pcrs_file,
-                                          TPML_DIGEST *pcr_values) {
-    //octet value of a pcr selection group
-    uint8_t group_val=0;
-    //total pcr indices per algorithm/ bank. Typically this is 24
-    uint8_t total_indices_for_this_alg=0;
-    //cumulative size total of selected indices per hashAlg
-    unsigned expected_pcr_input_file_size=0;
-    //loop counters
-    unsigned i, j, k, dgst_cnt=0;
-    const uint8_t bits_per_nibble[] = {0,1,1,2,1,2,2,3,1,2,2,3,2,3,3,4};
-
-    //Iterating the number of pcr banks selected
-    for (i=0; i < pcr_selections.count; i++) {
-        //Looping to check total pcr select bits in the pcr-select-octets for a bank
-        for (j=0; j < pcr_selections.pcrSelections[i].sizeofSelect; j++) {
-            group_val = pcr_selections.pcrSelections[i].pcrSelect[j];
-            total_indices_for_this_alg += bits_per_nibble[group_val & 0x0f];
-            total_indices_for_this_alg += bits_per_nibble[group_val >> 4];
-        }
-
-        //digest size returned per the hashAlg type
-        unsigned dgst_size = get_size_from_alg(pcr_selections.pcrSelections[i].hash);
-        if (!dgst_size) {
-            return false;
-        }
-        expected_pcr_input_file_size += (total_indices_for_this_alg * dgst_size);
-
-        //Cumulative total of all the pcr indices across banks selected in setlist
-        pcr_values->count += total_indices_for_this_alg;
-
-        /*
-         * Populating the digest sizes in the PCR digest list per algorithm bank
-         * Once iterated through all banks, creates an file offsets map for all pcr indices
-         */
-        for (k=0; k < total_indices_for_this_alg; k++) {
-            pcr_values->digests[dgst_cnt+k].t.size = dgst_size;
-        }
-        dgst_cnt++;
-
-        total_indices_for_this_alg=0;
-    }
-
-    //Check if the input pcrs file size is the same size as the pcr selection setlist
-    if (raw_pcrs_file) {
-        unsigned long filesize = 0;
-        bool result = files_get_file_size(raw_pcrs_file, &filesize);
-        if (!result) {
-            LOG_ERR("Could not retrieve raw_pcrs_file size\n");
-            return false;
-        }
-        if (filesize != expected_pcr_input_file_size) {
-            LOG_ERR("pcr-input-file filesize does not match pcr set-list");
-            return false;
-        }
-    }
-
-    return true;
-}
-
-static TPM_RC build_pcr_policy(TSS2_SYS_CONTEXT *sapi_context,
-                               SESSION *policy_session,
-                               TPML_PCR_SELECTION pcr_selections,
-                               char *raw_pcrs_file) {
-    // Calculate digest( with authhash alg) of pcrvalues in variable pcr_digest
-    TPM_RC rval=0;
-    TPML_DIGEST pcr_values = {
-        .count = 0
-    };
-
-    bool result = evaluate_populate_pcr_digests(pcr_selections, raw_pcrs_file,
-                                                &pcr_values);
-    if (!result) {
-        return TPM_RC_NO_RESULT;
-    }
-
-    //If PCR input for policy is from raw pcrs file
-    if (raw_pcrs_file) {
-        FILE *fp = fopen (raw_pcrs_file, "rb");
-        if (fp == NULL) {
-            LOG_ERR("Cannot open pcr-input-file %s", raw_pcrs_file);
-            return TPM_RC_NO_RESULT;
-        }
-       // Bank hashAlg values dictates the order of the list of digests
-        unsigned i;
-        for(i=0; i<pcr_values.count; i++) {
-            size_t sz = fread(&pcr_values.digests[i].t.buffer, 1, pcr_values.digests[i].t.size, fp);
-            if (sz != pcr_values.digests[i].t.size) {
-                const char *msg = ferror(fp) ? strerror(errno) :
-                        "end of file reached";
-                LOG_ERR("Reading from file \"%s\" failed: %s",
-                        raw_pcrs_file, msg);
-                fclose(fp);
-                return TPM_RC_NO_RESULT;
-            }
-        }
-        fclose(fp);
-    }
-
-    //If PCR input for policy is to be read from the TPM
-    if (!raw_pcrs_file) {
-        UINT32 pcr_update_counter;
-        TPML_PCR_SELECTION pcr_selection_out;
-        // Read PCRs
-        rval = Tss2_Sys_PCR_Read(sapi_context, 0,
-            &pcr_selections,
-            &pcr_update_counter, &pcr_selection_out, &pcr_values, 0);
-        if (rval != TPM_RC_SUCCESS) {
-            return rval;
-        }
-    }
-
-    // Calculate hashes
-    TPM2B_DIGEST pcr_digest =  TPM2B_TYPE_INIT(TPM2B_DIGEST, buffer);
-    rval = tpm_hash_sequence(sapi_context,
-        policy_session->authHash, pcr_values.count,
-        &pcr_values.digests[0], &pcr_digest);
-    if (rval != TPM_RC_SUCCESS) {
-        return rval;
-    }
-
-    // Call the PolicyPCR command
-    return Tss2_Sys_PolicyPCR(sapi_context, policy_session->sessionHandle,
-                              0, &pcr_digest, &pcr_selections, 0);
-}
-
-static TPM_RC start_policy_session (TSS2_SYS_CONTEXT *sapi_context,
-                                    SESSION **policy_session,
-                                    TPM_SE policy_session_type,
-                                    TPMI_ALG_HASH policy_digest_hash_alg) {
-    TPM2B_ENCRYPTED_SECRET encryptedSalt = TPM2B_EMPTY_INIT;
-    TPMT_SYM_DEF symmetric = {
-        .algorithm = TPM_ALG_NULL,
-    };
-    TPM2B_NONCE nonceCaller = TPM2B_EMPTY_INIT;
-    // Start policy session.
-    TPM_RC rval = tpm_session_start_auth_with_params(sapi_context,
-                                                     policy_session,
-                                                     TPM_RH_NULL, 0,
-                                                     TPM_RH_NULL, 0,
-                                                     &nonceCaller,
-                                                     &encryptedSalt,
-                                                     policy_session_type,
-                                                     &symmetric,
-                                                     policy_digest_hash_alg);
-    if (rval != TPM_RC_SUCCESS) {
-        LOG_ERR("Failed tpm session start auth with params\n");
-    }
-    return rval;
-}
-
-static TPM_RC build_policy(TSS2_SYS_CONTEXT *sapi_context,
-                           SESSION **policy_session,
-                           TPM_SE policy_session_type,
-                           TPMI_ALG_HASH policy_digest_hash_alg,
-                           TPML_PCR_SELECTION pcr_selections,
-                           char *raw_pcrs_file,
-                           TPM2B_DIGEST *policy_digest,
-                           bool extend_policy_session,
-        TPM_RC (*build_policy_function)(TSS2_SYS_CONTEXT *sapi_context,
-                                        SESSION *policy_session,
-                                        TPML_PCR_SELECTION pcr_selections,
-                                        char *raw_pcrs_file)) {
-    //Start policy session
-    TPM_RC rval = start_policy_session(sapi_context, policy_session,
-                                       policy_session_type,
-                                       policy_digest_hash_alg);
-    if (rval != TPM_RC_SUCCESS) {
-        LOG_ERR("Error starting the policy session.\n");
-        return rval;
-    }
-    // Issue policy command.
-    rval = (*build_policy_function)(pctx->sapi_context,
-                                    pctx->common_policy_options.policy_session,
-                                    pctx->pcr_policy_options.pcr_selections,
-                                    pctx->pcr_policy_options.raw_pcrs_file);
-    if (rval != TPM_RC_SUCCESS) {
-        LOG_ERR("Failed parse_policy_type_and_send_command\n");
-        return rval;
-    }
-    // Get Policy Hash
-    rval = Tss2_Sys_PolicyGetDigest(sapi_context,
-                                    (*policy_session)->sessionHandle,
-                                    0, policy_digest, 0);
-    if (rval != TPM_RC_SUCCESS) {
-        LOG_ERR("Failed Policy Get Digest\n");
-        return rval;
-    }
-
-    // Need to flush the session here.
-    if (!extend_policy_session) {
-        rval = Tss2_Sys_FlushContext(sapi_context,
-                                     (*policy_session)->sessionHandle);
-        if (rval != TPM_RC_SUCCESS) {
-            LOG_ERR("Failed Flush Context\n");
-            return rval;
-        }
-
-        // And remove the session from sessions table.
-        rval = tpm_session_auth_end(*policy_session);
-        if (rval != TPM_RC_SUCCESS) {
-            LOG_ERR("Failed deleting session from session table\n");
-            return rval;
-        }
-    }
-
-    return rval;
-}
-
 static TPM_RC parse_policy_type_specific_command (create_policy_ctx *pctx) {
     TPM_RC rval = TPM_RC_SUCCESS;
     if (!pctx->common_policy_options.policy_type.is_policy_type_selected){
@@ -328,15 +97,15 @@ static TPM_RC parse_policy_type_specific_command (create_policy_ctx *pctx) {
             LOG_ERR("Need the pcr list to account for in the policy.");
             return TPM_RC_NO_RESULT;
         }
-        rval = build_policy(pctx->sapi_context,
-                            &pctx->common_policy_options.policy_session,
-                            pctx->common_policy_options.policy_session_type,
-                            pctx->common_policy_options.policy_digest_hash_alg,
-                            pctx->pcr_policy_options.pcr_selections,
-                            pctx->pcr_policy_options.raw_pcrs_file,
-                            &pctx->common_policy_options.policy_digest,
-                            pctx->common_policy_options.extend_policy_session,
-                            build_pcr_policy);
+        rval = tpm2_policy_build(pctx->sapi_context,
+                                 &pctx->common_policy_options.policy_session,
+                                 pctx->common_policy_options.policy_session_type,
+                                 pctx->common_policy_options.policy_digest_hash_alg,
+                                 pctx->pcr_policy_options.pcr_selections,
+                                 pctx->pcr_policy_options.raw_pcrs_file,
+                                 &pctx->common_policy_options.policy_digest,
+                                 pctx->common_policy_options.extend_policy_session,
+                                 tpm2_policy_pcr_build);
         if (rval != TPM_RC_SUCCESS) {
             goto parse_policy_type_specific_command_error;
         }

--- a/tools/tpm2_createpolicy.c
+++ b/tools/tpm2_createpolicy.c
@@ -166,12 +166,6 @@ static bool evaluate_populate_pcr_digests(create_policy_ctx *pctx, TPML_DIGEST *
 }
 
 static TPM_RC build_pcr_policy(create_policy_ctx *pctx) {
-    //PCR inputs validation
-    if (pctx->pcr_policy_options.is_set_list == false) {
-        LOG_ERR("Need the pcr list to account for in the policy.");
-        return TPM_RC_NO_RESULT;
-    }
-
     // Calculate digest( with authhash alg) of pcrvalues in variable pcr_digest
     TPM_RC rval=0;
     TPML_DIGEST pcr_values = {
@@ -323,6 +317,12 @@ static TPM_RC parse_policy_type_specific_command (create_policy_ctx *pctx) {
     }
 
     if (pctx->common_policy_options.policy_type.PolicyPCR) {
+        //PCR inputs validation
+        if (pctx->pcr_policy_options.is_set_list == false) {
+            LOG_ERR("Need the pcr list to account for in the policy.");
+            return TPM_RC_NO_RESULT;
+        }
+        
         rval = build_policy(pctx, build_pcr_policy);
         if (rval != TPM_RC_SUCCESS) {
             goto parse_policy_type_specific_command_error;


### PR DESCRIPTION
This pull request does some refactor on build_policy() so the function is generic and can be moved to PCR lib to be reused by other tools. For start it's used by tpm2_unseal but I believe it can also be used by other tools (e.g: tpm2_nvread that needs the same as mentioned in issue #348).

By using build_policy(), the raw PCR hashes file is parsed correctly so this set also fixes issue #364.

To easy reviewing, I've tried to split the changes in as many logical steps as possible so each patch does only one thing.