### PR TITLE
Use identical types in comparison

### DIFF
--- a/lib/files.c
+++ b/lib/files.c
@@ -7,7 +7,7 @@
 #include "log.h"
 #include "tpm2_util.h"
 
-static bool get_file_size(FILE *fp, long *file_size, const char *path) {
+static bool get_file_size(FILE *fp, unsigned long *file_size, const char *path) {
 
     long current = ftell(fp);
     if (current < 0) {
@@ -33,13 +33,14 @@ static bool get_file_size(FILE *fp, long *file_size, const char *path) {
         return false;
     }
 
-    *file_size = size;
+    /* size cannot be negative at this point */
+    *file_size = (unsigned long)size;
     return true;
 }
 
 static bool read_bytes_from_file(FILE *f, UINT8 *buf, UINT16 *size,
                                  const char *path) {
-    long file_size;
+    unsigned long file_size;
     bool result = get_file_size(f, &file_size, path);
     if (!result) {
         /* get_file_size() logs errors */
@@ -49,7 +50,7 @@ static bool read_bytes_from_file(FILE *f, UINT8 *buf, UINT16 *size,
     /* max is bounded on UINT16 */
     if (file_size > *size) {
         LOG_ERR(
-                "File \"%s\" size is larger than buffer, got %ld expected less than %u",
+                "File \"%s\" size is larger than buffer, got %lu expected less than %u",
                 path, file_size, *size);
         return false;
     }
@@ -307,7 +308,7 @@ bool files_does_file_exist(const char *path) {
     return false;
 }
 
-bool files_get_file_size(const char *path, long *file_size) {
+bool files_get_file_size(const char *path, unsigned long *file_size) {
 
     bool result = false;
 

--- a/lib/files.h
+++ b/lib/files.h
@@ -95,13 +95,13 @@ bool files_does_file_exist(const char *path);
  * @param path
  *  The path of the file to retreive the size of.
  * @param file_size
- *  A pointer to a long to return the file size. The
+ *  A pointer to an unsigned long to return the file size. The
  *  pointed to value is valid only on a true return.
  *
  * @return
  *  True for success or False for error.
  */
-bool files_get_file_size(const char *path, long *file_size);
+bool files_get_file_size(const char *path, unsigned long *file_size);
 
 /**
  * Writes a TPM2.0 header to a file.

--- a/test/unit/test_files.c
+++ b/test/unit/test_files.c
@@ -220,7 +220,7 @@ static void test_file_size(void **state) {
     int rc = fflush(tf->file);
     assert_return_code(rc, errno);
 
-    long file_size;
+    unsigned long file_size;
     res = files_get_file_size(tf->path, &file_size);
     assert_true(res);
 
@@ -229,7 +229,7 @@ static void test_file_size(void **state) {
 
 static void test_file_size_bad_args(void **state) {
 
-    long file_size;
+    unsigned long file_size;
     bool res = files_get_file_size("this_should_be_a_bad_path", &file_size);
     assert_false(res);
 

--- a/tools/tpm2_createpolicy.c
+++ b/tools/tpm2_createpolicy.c
@@ -150,7 +150,7 @@ static bool evaluate_populate_pcr_digests(create_policy_ctx *pctx, TPML_DIGEST *
 
     //Check if the input pcrs file size is the same size as the pcr selection setlist
     if (pctx->pcr_policy_options.is_raw_pcrs_file) {
-        long filesize = 0;
+        unsigned long filesize = 0;
         bool result = files_get_file_size(pctx->pcr_policy_options.raw_pcrs_file, &filesize);
         if (!result) {
             LOG_ERR("Could not retrieve raw_pcrs_file size\n");

--- a/tools/tpm2_hash.c
+++ b/tools/tpm2_hash.c
@@ -137,7 +137,7 @@ static bool init(int argc, char *argv[], tpm_hash_ctx *ctx) {
 
     int opt;
     bool res;
-    long fileSize;
+    unsigned long fileSize;
     unsigned flags = 0;
     while ((opt = getopt_long(argc, argv, "H:g:I:o:t:", long_options, NULL))
             != -1) {
@@ -165,7 +165,7 @@ static bool init(int argc, char *argv[], tpm_hash_ctx *ctx) {
             }
             if (fileSize > MAX_DIGEST_BUFFER) {
                 LOG_ERR(
-                        "Input data too long: %ld, should be less than %d bytes\n",
+                        "Input data too long: %lu, should be less than %d bytes\n",
                         fileSize, MAX_DIGEST_BUFFER);
                 return false;
             }

--- a/tools/tpm2_sign.c
+++ b/tools/tpm2_sign.c
@@ -319,7 +319,7 @@ static bool init(int argc, char *argv[], tpm_sign_ctx *ctx) {
     /*
      * Process the msg file
      */
-    long file_size;
+    unsigned long file_size;
     result = files_get_file_size(inMsgFileName, &file_size);
     if (!result) {
         return false;
@@ -331,7 +331,7 @@ static bool init(int argc, char *argv[], tpm_sign_ctx *ctx) {
 
     if (file_size > 0xffff) {
         LOG_ERR(
-                "The message file was longer than a 16 bit length, got: %ld, expected less than: %d!",
+                "The message file was longer than a 16 bit length, got: %lu, expected less than: %d!",
                 file_size, 0x10000);
         return false;
     }

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -105,7 +105,7 @@ static bool verify_signature(tpm2_verifysig_ctx *ctx) {
 
 static TPM2B *message_from_file(const char *msg_file_path) {
 
-    long size;
+    unsigned long size;
 
     bool result = files_get_file_size(msg_file_path, &size);
     if (!result) {


### PR DESCRIPTION
Without this change, the compiler complains about a comparison between signed and unsigned integer expressions (filesize != expected_pcr_input_file_size) and aborts the compilation (due to Werror). Since expected_pcr_input_file_size exists only to be compared to filesize, its type can simply be changed to match that of filesize.