### PR TITLE
Fix uninitialized inPublic.t.publicArea.authPolicy

### DIFF
--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -242,7 +242,7 @@ execute_tool (int              argc,
 
     TPM2B_SENSITIVE_CREATE  inSensitive = TPM2B_EMPTY_INIT;
 
-    TPM2B_PUBLIC            inPublic;
+    TPM2B_PUBLIC            inPublic = TPM2B_EMPTY_INIT;
     TPMI_ALG_PUBLIC type;
     TPMI_ALG_HASH nameAlg;
     TPMI_DH_OBJECT parentHandle;

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -186,7 +186,7 @@ execute_tool (int               argc,
 
     TPM2B_SENSITIVE_CREATE inSensitive = TPM2B_EMPTY_INIT;
 
-    TPM2B_PUBLIC            inPublic;
+    TPM2B_PUBLIC            inPublic = TPM2B_EMPTY_INIT;
     TPMI_ALG_PUBLIC type;
     TPMI_ALG_HASH nameAlg;
     TPMI_RH_HIERARCHY hierarchy = TPM_RH_NULL;


### PR DESCRIPTION
In tpm2_create & tpm2_createprimary, if -L option was not specified
to initialize authPolicy, the authPolicy size of inPublic will be
random value and may cause sysapi context insufficient error.

Signed-off-by: Gang Wei <gang.wei@intel.com>