### PR TITLE
tpm2_create: check if keyed-hash algorithm was used when sealing data

### DIFF
--- a/man/tpm2_create.8.in
+++ b/man/tpm2_create.8.in
@@ -64,6 +64,7 @@ object attributes, optional
 .TP
 \fB\-I ,\-\-inFile\fR
 data file to be sealed, optional. If file is -, read from stdin.
+When sealing data only the TPM_ALG_KEYEDHASH algorithm is allowed.
 .TP
 \fB\-L ,\-\-policy\-file\fR
 the input policy file, optional

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -435,8 +435,14 @@ execute_tool (int              argc,
 
     if(P_flag == 0)
         sessionData.hmac.t.size = 0;
-    if(I_flag == 0)
+
+    if(I_flag == 0) {
         inSensitive.t.sensitive.data.t.size = 0;
+    } else if (type != TPM_ALG_KEYEDHASH) {
+        LOG_ERR("Only TPM_ALG_KEYEDHASH algorithm is allowed when sealing data\n");
+        return -19;
+    }
+
     if(K_flag == 0)
         inSensitive.t.sensitive.userAuth.t.size = 0;
     if(L_flag == 0)


### PR DESCRIPTION
The TCG specification is clear that only the TPM_ALG_KEYEDHASH algorithm
can be used when the user provides part of the the sensitive data.

The tpm2_create tool behaves according to the specification, but it may
not be clear to the users why it fails, unless are already familiar with
the specs. Make the tool gracefully fail and also add a note to man page.

Fixes: #369

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>