### PR TITLE
Algorithm nice names

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -150,7 +150,8 @@ check_PROGRAMS = \
     test/unit/test_files \
     test/unit/test_tpm2_header \
     test/unit/test_tpm2_nv_util \
-    test/unit/test_tpm2_alg_util
+    test/unit/test_tpm2_alg_util \
+    test/unit/test_pcr
 
 test_unit_tpm2_rc_decode_unit_CFLAGS  = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
 test_unit_tpm2_rc_decode_unit_LDADD   = $(CMOCKA_LIBS) $(LIB_COMMON)
@@ -180,6 +181,10 @@ test_unit_test_tpm2_nv_util_SOURCES  = test/unit/test_tpm2_nv_util.c
 test_unit_test_tpm2_alg_util_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
 test_unit_test_tpm2_alg_util_LDADD    = $(CMOCKA_LIBS) $(LIB_COMMON)
 test_unit_test_tpm2_alg_util_SOURCES  = test/unit/test_tpm2_alg_util.c
+
+test_unit_test_pcr_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
+test_unit_test_pcr_LDADD    = $(CMOCKA_LIBS) $(LIB_COMMON)
+test_unit_test_pcr_SOURCES  = test/unit/test_pcr.c
 
 endif
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -223,7 +223,7 @@ man8_MANS = \
     man/man8/tpm2_dictionarylockout.8 \
     man/man8/tpm2_createpolicy.8
 
-man/man8/%.8 : man/%.8.in man/tcti-options.troff man/tcti-environment.troff
+man/man8/%.8 : man/%.8.in man/tcti-options.troff man/tcti-environment.troff man/alg-common.troff man/hash-alg-common.troff
 	rm -f $@
 	mkdir -p man/man8
 if HAVE_TCTI_DEV
@@ -238,6 +238,10 @@ endif
 	    -e '/@TCTI_OPTIONS_INCLUDE@/d' \
 	    -e '/@TCTI_ENVIRONMENT_INCLUDE@/r man/tcti-environment.troff' \
 	    -e '/@TCTI_ENVIRONMENT_INCLUDE@/d' \
+	    -e '/@ALG_COMMON_INCLUDE@/r man/alg-common.troff' \
+	    -e '/@ALG_COMMON_INCLUDE@/d' \
+	    -e '/@HASH_ALG_COMMON_INCLUDE@/r man/hash-alg-common.troff' \
+	    -e '/@HASH_ALG_COMMON_INCLUDE@/d' \
 	    < $< >> $@
 
 CLEANFILES = $(man8_MANS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -95,7 +95,8 @@ lib_libcommon_a_SOURCES = \
     lib/tpm_session.c \
     lib/tpm2_policy.c \
     lib/tpm2_util.c \
-    lib/tpm2_nv_util.c
+    lib/tpm2_nv_util.c \
+    lib/tpm2_alg_util.c
 
 tools_tpm2_create_SOURCES = tools/tpm2_create.c tools/main.c
 tools_tpm2_createprimary_SOURCES = tools/tpm2_createprimary.c tools/main.c
@@ -148,7 +149,8 @@ check_PROGRAMS = \
     test/unit/test_string_bytes \
     test/unit/test_files \
     test/unit/test_tpm2_header \
-    test/unit/test_tpm2_nv_util
+    test/unit/test_tpm2_nv_util \
+    test/unit/test_tpm2_alg_util
 
 test_unit_tpm2_rc_decode_unit_CFLAGS  = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
 test_unit_tpm2_rc_decode_unit_LDADD   = $(CMOCKA_LIBS) $(LIB_COMMON)
@@ -174,6 +176,10 @@ test_unit_test_tpm2_header_SOURCES  = test/unit/test_tpm2_header.c
 test_unit_test_tpm2_nv_util_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
 test_unit_test_tpm2_nv_util_LDADD    = $(CMOCKA_LIBS) $(LIB_COMMON)
 test_unit_test_tpm2_nv_util_SOURCES  = test/unit/test_tpm2_nv_util.c
+
+test_unit_test_tpm2_alg_util_CFLAGS   = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
+test_unit_test_tpm2_alg_util_LDADD    = $(CMOCKA_LIBS) $(LIB_COMMON)
+test_unit_test_tpm2_alg_util_SOURCES  = test/unit/test_tpm2_alg_util.c
 
 endif
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -228,7 +228,7 @@ man8_MANS = \
     man/man8/tpm2_dictionarylockout.8 \
     man/man8/tpm2_createpolicy.8
 
-man/man8/%.8 : man/%.8.in man/common-options.troff man/tcti-options.troff man/tcti-environment.troff man/alg-common.troff man/hash-alg-common.troff man/object-alg-common.troff
+man/man8/%.8 : man/%.8.in man/common-options.troff man/tcti-options.troff man/tcti-environment.troff man/alg-common.troff man/hash-alg-common.troff man/object-alg-common.troff man/sign-alg-common.troff
 	rm -f $@
 	mkdir -p man/man8
 if HAVE_TCTI_DEV
@@ -249,6 +249,8 @@ endif
 	    -e '/@HASH_ALG_COMMON_INCLUDE@/d' \
 	    -e '/@OBJECT_ALG_COMMON_INCLUDE@/r man/object-alg-common.troff' \
 	    -e '/@OBJECT_ALG_COMMON_INCLUDE@/d' \
+	    -e '/@SIGN_ALG_COMMON_INCLUDE@/r man/sign-alg-common.troff' \
+	    -e '/@SIGN_ALG_COMMON_INCLUDE@/d' \
 	    < $< >> $@
 
 CLEANFILES = $(man8_MANS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -228,7 +228,7 @@ man8_MANS = \
     man/man8/tpm2_dictionarylockout.8 \
     man/man8/tpm2_createpolicy.8
 
-man/man8/%.8 : man/%.8.in man/tcti-options.troff man/tcti-environment.troff man/alg-common.troff man/hash-alg-common.troff man/object-alg-common.troff
+man/man8/%.8 : man/%.8.in man/common-options.troff man/tcti-options.troff man/tcti-environment.troff man/alg-common.troff man/hash-alg-common.troff man/object-alg-common.troff
 	rm -f $@
 	mkdir -p man/man8
 if HAVE_TCTI_DEV

--- a/Makefile.am
+++ b/Makefile.am
@@ -228,7 +228,7 @@ man8_MANS = \
     man/man8/tpm2_dictionarylockout.8 \
     man/man8/tpm2_createpolicy.8
 
-man/man8/%.8 : man/%.8.in man/tcti-options.troff man/tcti-environment.troff man/alg-common.troff man/hash-alg-common.troff
+man/man8/%.8 : man/%.8.in man/tcti-options.troff man/tcti-environment.troff man/alg-common.troff man/hash-alg-common.troff man/object-alg-common.troff
 	rm -f $@
 	mkdir -p man/man8
 if HAVE_TCTI_DEV
@@ -247,6 +247,8 @@ endif
 	    -e '/@ALG_COMMON_INCLUDE@/d' \
 	    -e '/@HASH_ALG_COMMON_INCLUDE@/r man/hash-alg-common.troff' \
 	    -e '/@HASH_ALG_COMMON_INCLUDE@/d' \
+	    -e '/@OBJECT_ALG_COMMON_INCLUDE@/r man/object-alg-common.troff' \
+	    -e '/@OBJECT_ALG_COMMON_INCLUDE@/d' \
 	    < $< >> $@
 
 CLEANFILES = $(man8_MANS)

--- a/lib/pcr.c
+++ b/lib/pcr.c
@@ -8,6 +8,7 @@
 #include "pcr.h"
 #include "log.h"
 #include "tpm2_util.h"
+#include "tpm2_alg_util.h"
 
 static int pcr_get_id(const char *arg, UINT32 *pcrId)
 {
@@ -46,7 +47,9 @@ static bool pcr_parse_selection(const char *str, size_t len, TPMS_PCR_SELECTION 
 
     snprintf(buf, strLeft - str + 1, "%s", str);
 
-    if (!tpm2_util_string_to_uint16(buf, &pcrSel->hash)) {
+    pcrSel->hash = tpm2_alg_util_from_optarg(buf);
+
+    if (pcrSel->hash == TPM_ALG_ERROR) {
         return false;
     }
 

--- a/lib/tpm2_alg_util.c
+++ b/lib/tpm2_alg_util.c
@@ -1,0 +1,122 @@
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <sapi/tpm20.h>
+
+#include "tpm2_alg_util.h"
+#include "tpm2_util.h"
+
+typedef struct alg_pair alg_pair;
+struct alg_pair {
+    const char *name;
+    TPM_ALG_ID id;
+};
+
+void tpm2_alg_util_for_each_alg(tpm2_alg_util_alg_iteraror iterator, void *userdata) {
+
+    static const alg_pair algs[] = {
+        { .name = "rsa", .id = ALG_RSA_VALUE },
+        { .name = "sha", .id = ALG_SHA_VALUE },
+        { .name = "sha1", .id = ALG_SHA1_VALUE },
+        { .name = "hmac", .id = ALG_HMAC_VALUE },
+        { .name = "aes", .id = ALG_AES_VALUE },
+        { .name = "mgf1", .id = ALG_MGF1_VALUE },
+        { .name = "keyedhash", .id = ALG_KEYEDHASH_VALUE },
+        { .name = "xor", .id = ALG_XOR_VALUE },
+        { .name = "sha256", .id = ALG_SHA256_VALUE },
+        { .name = "sha384", .id = ALG_SHA384_VALUE },
+        { .name = "sha512", .id = ALG_SHA512_VALUE },
+        { .name = "null", .id = ALG_NULL_VALUE },
+        { .name = "sm3_256", .id = ALG_SM3_256_VALUE },
+        { .name = "sm4", .id = ALG_SM4_VALUE },
+        { .name = "rsassa", .id = ALG_RSASSA_VALUE },
+        { .name = "rsaes", .id = ALG_RSAES_VALUE },
+        { .name = "rsapss", .id = ALG_RSAPSS_VALUE },
+        { .name = "oaep", .id = ALG_OAEP_VALUE },
+        { .name = "ecdsa", .id = ALG_ECDSA_VALUE },
+        { .name = "ecdh", .id = ALG_ECDH_VALUE },
+        { .name = "ecdaa", .id = ALG_ECDAA_VALUE },
+        { .name = "sm2", .id = ALG_SM2_VALUE },
+        { .name = "ecschnorr", .id = ALG_ECSCHNORR_VALUE },
+        { .name = "ecmqv", .id = ALG_ECMQV_VALUE },
+        { .name = "kdf1_sp800_56a", .id = ALG_KDF1_SP800_56A_VALUE },
+        { .name = "kdf2", .id = ALG_KDF2_VALUE },
+        { .name = "kdf1_sp800_108", .id = ALG_KDF1_SP800_108_VALUE },
+        { .name = "ecc", .id = ALG_ECC_VALUE },
+        { .name = "symcipher", .id = ALG_SYMCIPHER_VALUE },
+        { .name = "camellia", .id = ALG_CAMELLIA_VALUE },
+        { .name = "sha3_256", .id = ALG_SHA3_256_VALUE },
+        { .name = "sha3_384", .id = ALG_SHA3_384_VALUE },
+        { .name = "sha3_512", .id = ALG_SHA3_512_VALUE },
+        { .name = "ctr", .id = ALG_CTR_VALUE },
+        { .name = "ofb", .id = ALG_OFB_VALUE },
+        { .name = "cbc", .id = ALG_CBC_VALUE },
+        { .name = "cfb", .id = ALG_CFB_VALUE },
+        { .name = "ecb", .id = ALG_ECB_VALUE },
+    };
+
+    size_t i;
+    for (i=0; i < ARRAY_LEN(algs); i++) {
+        const alg_pair *alg = &algs[i];
+        bool result = iterator(alg->id, alg->name, userdata);
+        if (result) {
+            return;
+        }
+    }
+}
+
+static bool find_match(TPM_ALG_ID id, const char *name, void *userdata) {
+
+    alg_pair *search_data = (alg_pair *)userdata;
+
+    /*
+     * if name, then search on name, else
+     * search by id.
+     */
+    if (search_data->name && !strcmp(search_data->name, name)) {
+        search_data->id = id;
+        return true;
+    } else if (search_data->id == id) {
+        search_data->name = name;
+        return true;
+    }
+
+    return false;
+}
+
+TPM_ALG_ID tpm2_alg_util_strtoalg(const char *name) {
+
+    alg_pair userdata = {
+        .name = name,
+        .id = TPM_ALG_ERROR
+    };
+
+    if (name) {
+        tpm2_alg_util_for_each_alg(find_match, &userdata);
+    }
+
+    return userdata.id;
+}
+
+const char *tpm2_alg_util_algtostr(TPM_ALG_ID id) {
+
+    alg_pair userdata = {
+        .name = NULL,
+        .id = id
+    };
+
+    tpm2_alg_util_for_each_alg(find_match, &userdata);
+
+    return userdata.name;
+}
+
+TPM_ALG_ID tpm2_alg_util_from_optarg(char *optarg) {
+
+    TPM_ALG_ID halg;
+    bool res = tpm2_util_string_to_uint16(optarg, &halg);
+    if (!res) {
+        halg = tpm2_alg_util_strtoalg(optarg);
+    }
+    return halg;
+}

--- a/lib/tpm2_alg_util.h
+++ b/lib/tpm2_alg_util.h
@@ -1,0 +1,75 @@
+#ifndef LIB_TPM2_ALG_UTIL_H_
+#define LIB_TPM2_ALG_UTIL_H_
+
+#include <stdbool.h>
+
+#include <sapi/tpm20.h>
+
+/*
+ * The TSS has a bug where it was missing algs 0x27 trough 0x29.
+ * see: https://github.com/01org/TPM2.0-TSS/issues/476
+ * per https://trustedcomputinggroup.org/wp-content/uploads/TCG_Algorithm_Registry_Rev_1.24.pdf
+ * FIXME: https://github.com/01org/tpm2.0-tools/issues/375
+ */
+#ifndef ALG_SHA3_256_VALUE
+#define ALG_SHA3_256_VALUE 0x27
+#endif
+#ifndef ALG_SHA3_384_VALUE
+#define ALG_SHA3_384_VALUE 0x28
+#endif
+#ifndef ALG_SHA3_512_VALUE
+#define ALG_SHA3_512_VALUE 0x29
+#endif
+
+/**
+ * Iterator callback routine for iterating over known algorithm name and value
+ * pairs.
+ * @param id
+ *  The algorithm id.
+ * @param name
+ *  The associated "nice-name".
+ * @param userdata
+ *  A user supplied data pointer.
+ * @return
+ *  True to stop iterating, false to keep iterating.
+ */
+typedef bool (*tpm2_alg_util_alg_iteraror)(TPM_ALG_ID id, const char *name, void *userdata);
+
+/**
+ * Iterate over the algorithm name-value pairs calling the iterator callback for each pair.
+ * @param iterator
+ *  The iterator callback function.
+ * @param userdata
+ *  A pointer to user supplied data, this is passed to the iterator for each call.
+ */
+void tpm2_alg_util_for_each_alg(tpm2_alg_util_alg_iteraror iterator, void *userdata);
+
+/**
+ * Convert a "nice-name" string to an algorithm id.
+ * @param name
+ *  The "nice-name" to convert.
+ * @return
+ *  TPM_ALG_ERROR on error, or a valid algorithm identifier.
+ */
+TPM_ALG_ID tpm2_alg_util_strtoalg(const char *name);
+
+/**
+ * Convert an id to a nice-name.
+ * @param id
+ *  The id to convert.
+ * @return
+ *  The nice-name.
+ */
+const char *tpm2_alg_util_algtostr(TPM_ALG_ID id);
+
+/**
+ * Converts either a string from algrotithm number or algorithm nice-name to
+ * an algorithm id.
+ * @param optarg
+ *  The string to convert from an algorithm number or nice name.
+ * @return
+ *  TPM_ALG_ERROR on error or the algorithm id.
+ */
+TPM_ALG_ID tpm2_alg_util_from_optarg(char *optarg);
+
+#endif /* LIB_TPM2_ALG_UTIL_H_ */

--- a/man/alg-common.troff
+++ b/man/alg-common.troff
@@ -1,0 +1,10 @@
+Options tha take algorithms support "nice-names". Nice names, like sha1 can be
+used in place of the raw hex for sha1: 0x4. The nice names are converted by
+stripping the leading TPM_ALG_ from the Algorithm Name field and converting
+it to lower case. For instance TPM_ALG_SHA3_256 becomes sha3_256.
+.br
+The algorithms can be found at:
+.UR
+  https://trustedcomputinggroup.org/wp-content/uploads/TCG_Algorithm_Registry_Rev_1.24.pdf
+.UE.
+.br

--- a/man/hash-alg-common.troff
+++ b/man/hash-alg-common.troff
@@ -1,0 +1,9 @@
+.br
+Supported hash algorithms are:
+  '0x4' or 'sha1' for TPM_ALG_SHA1 (default)
+  '0xB' or 'sha256' for TPM_ALG_SHA256
+  '0xC' or 'sha384' for TPM_ALG_SHA384
+  '0xD' or 'sha512' for TPM_ALG_SHA512
+  '0x12' or 'sm3_256' for TPM_ALG_SM3_256
+.br
+\fBNOTE\fR: Your TPM may not support all algorithms.

--- a/man/object-alg-common.troff
+++ b/man/object-alg-common.troff
@@ -1,0 +1,8 @@
+.br
+Supported public object algorithms are:
+  '0x1' or 'rsa' for TPM_ALG_RSA (default)
+  '0x8' or 'keyedhash' for TPM_ALG_KEYEDHASH
+  '0x23' or 'ecc' for TPM_ALG_ECC
+  '0x25' or 'symcipher' for TPM_ALG_SYMCIPHER
+.br
+\fBNOTE\fR: Your TPM may not support all algorithms.

--- a/man/sign-alg-common.troff
+++ b/man/sign-alg-common.troff
@@ -1,0 +1,10 @@
+Supported algorithms are:
+  '0x5' or 'hmac' for TPM_ALG_HMAC (default)
+  '0x14' or 'rsassa' for TPM_ALG_RSASSA
+  '0x16' or 'rsapss' for TPM_ALG_RSAPSS
+  '0x18' or 'ecdsa' for TPM_ALG_ECDSA
+  '0x1A' or 'ecdaa' for TPM_ALG_ECDAA
+  '0x1B' or 'sm2' for TPM_ALG_SM2
+  '0x1C' or 'ecschnorr' for TPM_ALG_ECSCHNORR
+.br
+\fBNOTE\fR: Your TPM may not support all algorithms.

--- a/man/tpm2_certify.8.in
+++ b/man/tpm2_certify.8.in
@@ -73,9 +73,7 @@ the object handle's password, optional
 .TP
 \fB\-K ,\-\-pwdk\fR
 the keyHandle's password, optional
-.TP
-\fB\-g ,\-\-halg\fR
-the hash algorithm used to digest the message  0x0004 TPM_ALG_SHA1   0x000B TPM_ALG_SHA256   0x000C TPM_ALG_SHA384   0x000D TPM_ALG_SHA512   0x0012 TPM_ALG_SM3_256 
+@HALG_COMMON_INCLUDE@
 .TP
 \fB\-a ,\-\-attestFile\fR
 output file name, record the attestation structure

--- a/man/tpm2_create.8.in
+++ b/man/tpm2_create.8.in
@@ -52,12 +52,14 @@ password for parent key, optional
 .TP
 \fB\-K ,\-\-pwdk\fR
 password for key, optional
-.TP
 \fB\-g ,\-\-halg\fR
-algorithm used for computing the Name of the  object   0x0004 TPM_ALG_SHA1   0x000B TPM_ALG_SHA256   0x000C TPM_ALG_SHA384   0x000D TPM_ALG_SHA512   0x0012 TPM_ALG_SM3_256 
+The hash algorithm to use.
+@ALG_COMMON_INCLUDE@
+@HASH_ALG_COMMON_INCLUDE@
 .TP
 \fB\-G ,\-\-kalg\fR
-algorithm associated with this object  0x0001 TPM_ALG_RSA   0x0008 TPM_ALG_KEYEDHASH   0x0023 TPM_ALG_ECC   0x0025 TPM_ALG_SYMCIPHER 
+algorithm associated with this object. It accepts friendly names just like -g option.
+@OBJECT_ALG_COMMON_INCLUDE@
 .TP
 \fB\-A ,\-\-objectAttribute\fR
 object attributes, optional

--- a/man/tpm2_createpolicy.8.in
+++ b/man/tpm2_createpolicy.8.in
@@ -41,17 +41,10 @@ File to save the policy digest.
 \fB\-P\fR,\ \fB\-\-policy-pcr\fR
 Identifies the PCR policy type for policy creation.
 .TP
-\fB\-g\fR,\ \fB\-\-policy-digest-alg\fR=[0x4|0xB|0xC|0xD|0x12]
+\fB\-g\fR,\ \fB\-\-policy-digest-alg\fR
 Hash algorithm used in computation of the policy digest.
-.br
-Supported options are:
-  '0x4' for TPM_ALG_SHA1
-  '0xB' for TPM_ALG_SHA256
-  '0xC' for TPM_ALG_SHA384
-  '0xD' for TPM_ALG_SHA512
-  '0x12' for TPM_ALG_SM3_256
-.br
-\fBNOTE\fR: Your TPM may not support all algorithms.
+@ALG_COMMON_INCLUDE@
+@HASH_ALG_COMMON_INCLUDE@
 .TP
 \fB\-L\fR,\ \fB\-\-set-list\fR=[string]
 The list of pcr banks and selected PCRs' ids   (0~23) for each bank.

--- a/man/tpm2_createprimary.8.in
+++ b/man/tpm2_createprimary.8.in
@@ -52,27 +52,15 @@ Optional authorization string if authorization is required to create object unde
 \fB\-K\fR,\ \fB\-\-pwdk\fR=[string]
 Optional authorization string for the newly created object.
 .TP
-\fB\-g\fR,\ \fB\-\-halg\fR=[0x4|0xB|0xC|0xD|0x12]
+\fB\-g\fR,\ \fB\-\-halg\fR
 Hash algorithm used in the computation of the object name.
-.br
-Supported options are:
-  '0x4' for TPM_ALG_SHA1
-  '0xB' for TPM_ALG_SHA256
-  '0xC' for TPM_ALG_SHA384
-  '0xD' for TPM_ALG_SHA512
-  '0x12' for TPM_ALG_SM3_256
-.br
-\fBNOTE\fR: Your TPM may not support all algorithms.
+@ALG_COMMON_INCLUDE@
+@HASH_ALG_COMMON_INCLUDE@
 .TP
-\fB\-G\fR,\ \fB\-\-kalg\fR=[0x1|0x8|0x23|0x25] 
-Algorithm type for generated key.
-.br
-Supported options are:
-  '0x1' for TPM_ALG_RSA
-  '0x8' for TPM_ALG_KEYEDHASH
-  '0x23' for TPM_ALG_ECC
-  '0x25' for TPM_ALG_SYMCIPHER
-.TP
+\fB\-G\fR,\ \fB\-\-kalg\fR=[algorithm]
+Algorithm type for generated key. It supports friendly names like the -g option.
+@ALG_COMMON_INCLUDE@
+@OBJECT_ALG_COMMON_INCLUDE@
 \fB\-C\fR,\ \fB\-\-context\fR=[filepath]
 An optional file used to store the object context returned.
 .TP

--- a/man/tpm2_getmanufec.8.in
+++ b/man/tpm2_getmanufec.8.in
@@ -50,8 +50,10 @@ specifies the EK password when created  (string,optional,default:NULL).
 \fB\-H ,\-\-handle\fR
 specifies the handle used to make EK  persistent (hex). 
 .TP
-\fB\-g ,\-\-alg\fR
-specifies the algorithm type of EK  (default:0x01/TPM_ALG_RSA). 
+-\fB\-g ,\-\-alg\fR
+-specifies the algorithm type of EK.
+@ALG_COMMON_INCLUDE@
+@OBJECT_ALG_COMMON_INCLUDE@
 .TP
 \fB\-f ,\-\-file\fR
 specifies the file used to save the public  portion of EK. 

--- a/man/tpm2_getpubak.8.in
+++ b/man/tpm2_getpubak.8.in
@@ -65,14 +65,18 @@ specifies the handle of EK (hex).
 \fB\-k ,\-\-akHandle\fR
 specifies the handle used to make AK  persistent (hex). 
 .TP
-\fB\-g ,\-\-alg\fR
-specifies the algorithm type of AK  (default:0x01/TPM_ALG_RSA):   TPM_ALG_RSA 0x0001   TPM_ALG_KEYEDHASH 0x0008   TPM_ALG_ECC 0x0023 
+-\fB\-g ,\-\-alg\fR
+-specifies the algorithm type of AK.
+@ALG_COMMON_INCLUDE@
+@OBJECT_ALG_COMMON_INCLUDE@
 .TP
 \fB\-D ,\-\-digestAlg\fR
-specifies the algorithm of digest.  0x0004 TPM_ALG_SHA1   0x000B TPM_ALG_SHA256   0x000C TPM_ALG_SHA384   0x000D TPM_ALG_SHA512   0x0012 TPM_ALG_SM3_256 
+Like -g, but specifies the algorithm of digest.
+@HASH_ALG_COMMON_INCLUDE@
 .TP
 \fB\-s ,\-\-signAlg\fR
-specifies the algorithm of sign.  0x0005 TPM_ALG_HMAC   0x0014 TPM_ALG_RSASSA   0x0016 TPM_ALG_RSAPSS   0x0018 TPM_ALG_ECDSA   0x001A TPM_ALG_ECDAA   0x001B TPM_ALG_SM2   0x001C TPM_ALG_ECSCHNORR 
+Like -g, but specifies the algorithm of sign.
+@SIGN_ALG_COMMON_INCLUDE@
 .TP
 \fB\-f ,\-\-file\fR
 specifies the file used to save the public  portion of AK. 

--- a/man/tpm2_getpubek.8.in
+++ b/man/tpm2_getpubek.8.in
@@ -63,7 +63,9 @@ specifies the EK password when created  (string, optional, default:NULL).
 specifies the handle used to make EK  persistent (hex). 
 .TP
 \fB\-g ,\-\-alg\fR
-specifies the algorithm type of EK  (default:0x01/TPM_ALG_RSA).   TPM_ALG_RSA 0x0001   TPM_ALG_KEYEDHASH 0x0008   TPM_ALG_ECC 0x0023   TPM_ALG_SYMCIPHER 0x0025 
+specifies the algorithm type of EK.
+@ALG_COMMON_INCLUDE@
+@OBJECT_ALG_COMMON_INCLUDE@
 .TP
 \fB\-f ,\-\-file\fR
 specifies the file used to save the public  portion of EK. 

--- a/man/tpm2_hash.8.in
+++ b/man/tpm2_hash.8.in
@@ -48,10 +48,12 @@ hash is safe to sign.
 .SH OPTIONS
 .TP
 \fB\-H ,\-\-hierarchy\fR
-hierarchy to use for the ticket  e TPM_RH_ENDORSEMENT   o TPM_RH_OWNER   p TPM_RH_PLATFORM   n TPM_RH_NULL 
+hierarchy to use for the ticket  e TPM_RH_ENDORSEMENT   o TPM_RH_OWNER   p TPM_RH_PLATFORM   n TPM_RH_NULL
 .TP
 \fB\-g ,\-\-halg\fR
-algorithm for the hash being computed  0x0004 TPM_ALG_SHA1   0x000B TPM_ALG_SHA256   0x000C TPM_ALG_SHA384   0x000D TPM_ALG_SHA512   0x0012 TPM_ALG_SM3_256 
+The hash algorithm to use.
+@ALG_COMMON_INCLUDE@
+@HASH_ALG_COMMON_INCLUDE@
 .TP
 \fB\-I ,\-\-infile\fR
 file containning the data to be hashed

--- a/man/tpm2_hmac.8.in
+++ b/man/tpm2_hmac.8.in
@@ -49,9 +49,10 @@ filename of the key context used for the  operation
 .TP
 \fB\-P ,\-\-pwdk\fR
 the keyHandle's password, optional
-.TP
 \fB\-g ,\-\-halg\fR
-algorithm for the hash being computed  0x0004 TPM_ALG_SHA1   0x000B TPM_ALG_SHA256   0x000C TPM_ALG_SHA384   0x000D TPM_ALG_SHA512   0x0012 TPM_ALG_SM3_256 
+The hash algorithm to use.
+@ALG_COMMON_INCLUDE@
+@HASH_ALG_COMMON_INCLUDE@
 .TP
 \fB\-I ,\-\-infile\fR
 file containning the data to be HMACed

--- a/man/tpm2_listpcrs.8.in
+++ b/man/tpm2_listpcrs.8.in
@@ -51,7 +51,9 @@ the caller know the pcr value length corresponding to the given bank/algorithm.
 .SH OPTIONS
 .TP
 \fB\-g ,\-\-algorithim\fR
-The algorithm id, optional  0x0004 TPM_ALG_SHA1   0x000B TPM_ALG_SHA256   0x000C TPM_ALG_SHA384   0x000D TPM_ALG_SHA512   0x0012 TPM_ALG_SM3_256 
+The algorithm id.
+@ALG_COMMON_INCLUDE@
+@HASH_ALG_COMMON_INCLUDE@
 .TP
 \fB\-o ,\-\-output\fR
 The file to hold the PCR values in binary  format, optional 

--- a/man/tpm2_quote.8.in
+++ b/man/tpm2_quote.8.in
@@ -51,7 +51,9 @@ AK handle's Password
 The list of selected PCRs' ids, 0~23
 .TP
 \fB\-g ,\-\-algorithm\fR
-The algorithm id
+The algorithm id.
+@@ALG_COMMON_INCLUDE@
+@OBJECT_ALG_COMMON_INCLUDE@
 .TP
 \fB\-L ,\-\-selList\fR
 The list of pcr banks and selected PCRs' ids   (0~23) for each bank 

--- a/man/tpm2_sign.8.in
+++ b/man/tpm2_sign.8.in
@@ -60,7 +60,9 @@ filename of the key context used for the operation
 the password of key, optional
 .TP
 \fB\-g ,\-\-halg\fR
-the hash algorithm used to digest the message  0x0004 TPM_ALG_SHA1   0x000B TPM_ALG_SHA256   0x000C TPM_ALG_SHA384   0x000D TPM_ALG_SHA512   0x0012 TPM_ALG_SM3_256 
+the hash algorithm used to digest the message.
+@@ALG_COMMON_INCLUDE@
+@HASH_ALG_COMMON_INCLUDE@
 .TP
 \fB\-m ,\-\-msg\fR
 the message file, containning the content to be  digested 

--- a/man/tpm2_verifysignature.8.in
+++ b/man/tpm2_verifysignature.8.in
@@ -60,7 +60,9 @@ handle of public key that will be used in the  validation
 filename of the key context used for the operation
 .TP
 \fB\-g ,\-\-halg\fR
-the hash algorithm used to digest the message  0x0004 TPM_ALG_SHA1   0x000B TPM_ALG_SHA256   0x000C TPM_ALG_SHA384   0x000D TPM_ALG_SHA512   0x0012 TPM_ALG_SM3_256 
+the hash algorithm used to digest the message.
+@@ALG_COMMON_INCLUDE@
+@HASH_ALG_COMMON_INCLUDE@
 .TP
 \fB\-m ,\-\-msg\fR
 the input message file, containning the content  to be digested 

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -7,3 +7,6 @@
 !*.sh
 !*.c
 !*.h
+
+# ...even if they are in subdirectories
+!*/

--- a/test/system/test_algs_tpm2_getpubak.sh
+++ b/test/system/test_algs_tpm2_getpubak.sh
@@ -61,11 +61,11 @@ if [ $? != 0 ];then
 fi
 ##   ./tpm2_getpubak  -e "$handle_ek" -k $handle_ak  -g $ak_alg -D $digestAlg -s $signAlg -f ak.pub_"$kalg_p"_"$halg"_"$digestAlg"_"$signAlg" -n ak.name_"$kalg_p"_"$halg"_"$digestAlg"_"$signAlg"
 
-for  ak_alg in 0x0001 0x0008 0x0023  
- do
-   for  digestAlg in 0x0004 0x000B 0x000C 0x000D 0x0012
+for  ak_alg in rsa 0x0008 0x0023
+do
+   for  digestAlg in 0x0004 sha256 0x000C 0x000D 0x0012
    do 
-    for  signAlg in 0x0005 0x0014 0x0016 0x0018 0x001A 0x001B 0x001C
+    for  signAlg in hmac 0x0014 0x0016 0x0018 0x001A sm2 0x001C
     do
 
   tpm2_getpubak  -E "$handle_ek" -k $handle_ak  -g $ak_alg -D $digestAlg -s $signAlg -f ak.pub_"$ak_alg"_"$digestAlg"_"$signAlg" -n ak.name_"$ak_alg"_"$digestAlg"_"$signAlg"

--- a/test/system/test_algs_tpm2_getpubek.sh
+++ b/test/system/test_algs_tpm2_getpubek.sh
@@ -54,7 +54,7 @@ Pass()
 rm test_getpub*.log
 rm ek.pub*
 
-for  kalg_p in 0x0001 0x0008 0x0023 0x0025   
+for  kalg_p in sha1 0x0008 0x0023 symcipher
  do
 ##echo $ek_e	
  tpm2_getpubek  -H 0x8101000"$ek_e" -g $kalg_p -f ek.pub_"$kalg_p" 

--- a/test/system/test_algs_tpm2_hmac.sh
+++ b/test/system/test_algs_tpm2_hmac.sh
@@ -52,7 +52,7 @@ fi
 #for  halg_p in 0x0004 0x000B 0x000C 0x000D 0x0012  
 for  context_p in `ls context_load*`   
   do
-   for halg in 0x0004 0x000B 0x000C
+   for halg in sha1 sha256 sha384
      do
 	
 ##  echo "halg_p: "$halg_p" kalg_p: "$kalg_p"" >>test.log 

--- a/test/system/test_tpm2_certify.sh
+++ b/test/system/test_tpm2_certify.sh
@@ -38,8 +38,9 @@ file_certify_key_name=name.load.B1_B8
 file_output_attest=attest.out
 file_output_signature=certify_signature.out 
   
-
+# do not update alg_hash without updating alg_hash_name
 alg_hash=0x000B
+alg_hash_name=sha256
 alg_primary_key=0x0001
 alg_certify_key=0x0001
 
@@ -62,7 +63,7 @@ if [ $? != 0 ];then
 echo "load fail, please check the environment or parameters!"
 exit 1
 fi
-tpm2_certify -C $file_primary_key_ctx  -c $file_certify_key_ctx -g $alg_hash -a $file_output_attest -s $file_output_signature
+tpm2_certify -C $file_primary_key_ctx  -c $file_certify_key_ctx -g $alg_hash_name -a $file_output_attest -s $file_output_signature
 if [ $? != 0 ];then
  echo "certify fail, please check the environment or parameters!"
  exit 1

--- a/test/system/test_tpm2_create_all.sh
+++ b/test/system/test_tpm2_create_all.sh
@@ -48,9 +48,9 @@ fi
 
 for pCtx in `ls ctx.cpri*`
     do
-    for gAlg in 0x04 0x0B 0x0C 0x0D 0x12
+    for gAlg in sha1 0x0B sha384 0x0D 0x12
         do 
-        for GAlg in 0x01 0x08 0x23 0x25
+        for GAlg in rsa 0x08 ecc 0x25
             do 
             tpm2_create -c $pCtx -g $gAlg -G $GAlg -o opu."$pCtx".g"$gAlg".G"$GAlg" -O opr."$pCtx".g"$gAlg".G"$GAlg"
             if [ $? != 0 ];then 
@@ -70,7 +70,7 @@ if [ $? != 0 ];then
  exit 1
 fi
 
-tpm2_create -c prim.ctx -g 0xb -G 0x1 -L policy.bin -o key.pub -O key.priv -E
+tpm2_create -c prim.ctx -g sha256 -G 0x1 -L policy.bin -o key.pub -O key.priv -E
 if [ $? != 0 ];then
  echo "create object failed"
  exit 1

--- a/test/system/test_tpm2_createpolicy.sh
+++ b/test/system/test_tpm2_createpolicy.sh
@@ -35,23 +35,21 @@
 
 declare -A expected_policy_digest=(["sha1"]="f28230c080bbe417141199e36d18978228d8948fc10a6a24921b9eba6bb1d988"
                                    ["sha256"]="33e36e786c878632494217c3f490e74ca0a3a122a8a4f3c5302500df3b32b3b8")
-declare -A hash_name=([0x4]="sha1" [0xb]="sha256")
 pcr_index=0
 
-for halg in 0x4 0xb
+for halg in sha1 sha256
 do
-    hash=${hash_name[${halg}]}
     tpm2_createpolicy -P -L ${halg}:${pcr_index} -f policy.file
     if [ $? != 0 ];then
         echo "createpolicy command failed, please check the environment or parameters!"
         exit 1
     fi
 
-    if [ $(xxd -p policy.file | tr -d '\n' ) != "${expected_policy_digest[${hash}]}" ];then
-        echo "Failure: Creating Policy Digest with PCR policy for index ${pcr_index} and ${hash} pcr index hash"
+    if [ $(xxd -p policy.file | tr -d '\n' ) != "${expected_policy_digest[${halg}]}" ];then
+        echo "Failure: Creating Policy Digest with PCR policy for index ${pcr_index} and ${halg} pcr index hash"
         exit 1
     else
-        echo "Success: Creating Policy Digest with PCR policy for index ${pcr_index} and ${hash} pcr index hash"
+        echo "Success: Creating Policy Digest with PCR policy for index ${pcr_index} and ${halg} pcr index hash"
     fi
 done
 

--- a/test/system/test_tpm2_createprimary_all.sh
+++ b/test/system/test_tpm2_createprimary_all.sh
@@ -36,9 +36,9 @@ gAlg=
 GAlg=
 
 rm createprimary.error.log rf
-for gAlg in 0x04 0x0B 0x0C 0x0D 0x12
+for gAlg in 0x04 sha256 0x0C 0x0D sm3_256
     do 
-        for GAlg in 0x01 0x08 0x23 0x25
+        for GAlg in 0x01 keyedhash ecc 0x25
             do 
                 for Atype in o e p n 
                     do 

--- a/test/system/test_tpm2_getmanufec.sh
+++ b/test/system/test_tpm2_getmanufec.sh
@@ -44,7 +44,7 @@ d76e06520b64f2a1da1b331469aa000000000000000000000000000000000000\
 e29dae839f5b4ca0f5de27c9522c23c54e1c2ce57859525118bd4470b18180ee\
 f78ae4267bcd0000" | xxd -r -p > test_ek.pub
 
-tpm2_getmanufec -g 0x01 -O -N -U -E ECcert.bin -f test_ek.pub -S https://ekop.intel.com/ekcertservice/
+tpm2_getmanufec -g rsa -O -N -U -E ECcert.bin -f test_ek.pub -S https://ekop.intel.com/ekcertservice/
 if [ $? != 0 ];then
  echo "tpm2_getmanufec command failed, please check the environment or parameters!"
  exit 1

--- a/test/system/test_tpm2_hash.sh
+++ b/test/system/test_tpm2_hash.sh
@@ -32,7 +32,7 @@
 #!/bin/sh
 
 #this script is for hash case testing 
-halg=0x000B
+halg=sha256
 Hierarchy=e
 
 rm -f  hash_out_"$Hierarchy"_"$halg" hash_tk_"$Hierarchy"_"$halg" 

--- a/test/system/test_tpm2_hash_all.sh
+++ b/test/system/test_tpm2_hash_all.sh
@@ -43,7 +43,7 @@ fi
 
 for Hierarchy in e o p n  
 do
-	for halg in 0x0004 0x000B 0x000C 0x000D 0x0012
+	for halg in sha1 sha256 sha384 sha512 sm3_256
 	do
 	
 	tpm2_hash -H $Hierarchy -g $halg -I hash.in -o hash_out_"$Hierarchy"_"$halg" -t hash_tk_"$Hierarchy"_"$halg"

--- a/test/system/test_tpm2_listpcrs.sh
+++ b/test/system/test_tpm2_listpcrs.sh
@@ -48,7 +48,7 @@ fi
 
 rm -rf pcrs
 
-tpm2_listpcrs -L 0x04:17,18,19+0x0b:0,17,18,19 -o pcrs
+tpm2_listpcrs -L 0x04:17,18,19+sha256:0,17,18,19 -o pcrs
 
 if [ $? != 0 ];then 
  echo "listpcrs  fail!"

--- a/test/system/test_tpm2_quote.sh
+++ b/test/system/test_tpm2_quote.sh
@@ -30,8 +30,8 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 #;**********************************************************************;
 #!/bin/bash
-alg_primary_obj=0x000B
-alg_primary_key=0x0001
+alg_primary_obj=sha256
+alg_primary_key=rsa
 alg_create_obj=0x000B
 alg_create_key=0x0008
 

--- a/test/system/test_tpm2_sign.sh
+++ b/test/system/test_tpm2_sign.sh
@@ -42,7 +42,7 @@ file_output_data=sig.4
   
 handle_signing_key=0x81010005
 
-alg_hash=0x000B
+alg_hash=sha256
 alg_primary_key=0x0001
 alg_signing_key=0x0008
 

--- a/test/system/test_tpm2_verifysignature.sh
+++ b/test/system/test_tpm2_verifysignature.sh
@@ -44,7 +44,7 @@ file_input_data_hash_tk=secret_hash_tk.data
 
 handle_signing_key=0x81010005
 
-alg_hash=0x000B
+alg_hash=sha256
 alg_primary_key=0x0001
 alg_signing_key=0x0001
 
@@ -87,7 +87,6 @@ if [ ! -e "$file_output_data" ];then
 fi
 
 
-#tpm2_verifysignature -c context_load_out_6  -g 0x000B -m secret.data  -s sign.f1 -t tickt_verify_sign.out              
 tpm2_verifysignature -c $file_signing_key_ctx  -g $alg_hash -m $file_input_data  -s $file_output_data -t $file_verify_tk_data
 if [ $? != 0 ];then
 	fail verifysignature   

--- a/test/unit/test_pcr.c
+++ b/test/unit/test_pcr.c
@@ -1,0 +1,69 @@
+//**********************************************************************;
+// Copyright (c) 2016, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <setjmp.h>
+
+#include <cmocka.h>
+#include <sapi/tpm20.h>
+
+#include "pcr.h"
+#include "tpm2_util.h"
+
+static void test_pcr_alg_nice_names(void **state) {
+
+    (void) state;
+
+    TPML_PCR_SELECTION friendly_pcr_selections =
+            TPML_PCR_SELECTION_EMPTY_INIT;
+
+    bool result = pcr_parse_selections("sha256:16,17,18+0x0b:16,17,18",
+            &friendly_pcr_selections);
+    assert_true(result);
+
+    TPML_PCR_SELECTION raw_pcr_selections =
+            TPML_PCR_SELECTION_EMPTY_INIT;
+
+    result = pcr_parse_selections("0xb:16,17,18+0x0b:16,17,18",
+            &raw_pcr_selections);
+    assert_true(result);
+
+    assert_memory_equal(&friendly_pcr_selections, &raw_pcr_selections,
+            sizeof(raw_pcr_selections));
+}
+
+int main(int argc, char* argv[]) {
+    (void) argc;
+    (void) argv;
+
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_pcr_alg_nice_names)
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/test/unit/test_tpm2_alg_util.c
+++ b/test/unit/test_tpm2_alg_util.c
@@ -1,0 +1,277 @@
+//**********************************************************************;
+// Copyright (c) 2016, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <setjmp.h>
+
+#include <cmocka.h>
+#include <sapi/tpm20.h>
+
+#include "tpm2_util.h"
+#include "tpm2_alg_util.h"
+
+#define xstr(s) str(s)
+#define str(s) #s
+
+#define single_item_test_get(friendly) \
+    cmocka_unit_test(test_tpm2_alg_util_convert_##friendly)
+
+#define single_item_test(friendly, value) \
+    static void test_tpm2_alg_util_convert_##friendly(void **state) { \
+    \
+        (void)state; \
+    \
+        TPM_ALG_ID found_id = tpm2_alg_util_strtoalg(str(friendly)); \
+        const char *found_str = tpm2_alg_util_algtostr(value); \
+        TPM_ALG_ID from_hex_str = tpm2_alg_util_from_optarg(xstr(value));    \
+        TPM_ALG_ID from_nice_str = tpm2_alg_util_from_optarg(str(friendly));    \
+        \
+        assert_ptr_not_equal(found_id, NULL); \
+        assert_string_equal(str(friendly), found_str); \
+        assert_int_equal(value, found_id); \
+        assert_int_equal(value, from_hex_str); \
+        assert_int_equal(value, from_nice_str); \
+    }
+
+single_item_test(rsa, ALG_RSA_VALUE)
+/*
+ * sha sha1 is it's own test, as alg to string
+ * can return either, based on the map ordering.
+ *
+ */
+single_item_test(hmac, ALG_HMAC_VALUE)
+single_item_test(aes, ALG_AES_VALUE)
+single_item_test(mgf1, ALG_MGF1_VALUE)
+single_item_test(keyedhash, ALG_KEYEDHASH_VALUE)
+single_item_test(xor, ALG_XOR_VALUE)
+single_item_test(sha256, ALG_SHA256_VALUE)
+single_item_test(sha384, ALG_SHA384_VALUE)
+single_item_test(sha512, ALG_SHA512_VALUE)
+single_item_test(null, ALG_NULL_VALUE)
+single_item_test(sm3_256, ALG_SM3_256_VALUE)
+single_item_test(sm4, ALG_SM4_VALUE)
+single_item_test(rsassa, ALG_RSASSA_VALUE)
+single_item_test(rsaes, ALG_RSAES_VALUE)
+single_item_test(rsapss, ALG_RSAPSS_VALUE)
+single_item_test(oaep, ALG_OAEP_VALUE)
+single_item_test(ecdsa, ALG_ECDSA_VALUE)
+single_item_test(ecdh, ALG_ECDH_VALUE)
+single_item_test(ecdaa, ALG_ECDAA_VALUE)
+single_item_test(sm2, ALG_SM2_VALUE)
+single_item_test(ecschnorr, ALG_ECSCHNORR_VALUE)
+single_item_test(ecmqv, ALG_ECMQV_VALUE)
+single_item_test(kdf1_sp800_56a, ALG_KDF1_SP800_56A_VALUE)
+single_item_test(kdf2, ALG_KDF2_VALUE)
+single_item_test(kdf1_sp800_108, ALG_KDF1_SP800_108_VALUE)
+single_item_test(ecc, ALG_ECC_VALUE)
+single_item_test(symcipher, ALG_SYMCIPHER_VALUE)
+single_item_test(camellia, ALG_CAMELLIA_VALUE)
+single_item_test(sha3_256, ALG_SHA3_256_VALUE)
+single_item_test(sha3_384, ALG_SHA3_384_VALUE)
+single_item_test(sha3_512, ALG_SHA3_512_VALUE)
+single_item_test(ctr, ALG_CTR_VALUE)
+single_item_test(ofb, ALG_OFB_VALUE)
+single_item_test(cbc, ALG_CBC_VALUE)
+single_item_test(cfb, ALG_CFB_VALUE)
+single_item_test(ecb, ALG_ECB_VALUE)
+
+typedef struct find_unk_data find_unk_data;
+struct find_unk_data {
+    TPM_ALG_ID *ids;
+    size_t len;
+};
+
+static bool find_unkown(TPM_ALG_ID id, const char *name, void *userdata) {
+
+    (void) name;
+
+    find_unk_data *d = (find_unk_data *) userdata;
+
+    size_t i = 0;
+    for (i = 0; i < d->len; i++) {
+        if (d->ids[i] == id) {
+            d->ids[i] = TPM_ALG_ERROR;
+        }
+    }
+
+    return false;
+}
+
+static void test_tpm2_alg_util_sha_test(void **state) {
+
+    (void) state;
+
+    TPM_ALG_ID sha_found_id = tpm2_alg_util_strtoalg("sha");
+    const char *sha_found_str = tpm2_alg_util_algtostr(ALG_SHA_VALUE);
+
+    TPM_ALG_ID sha1_found_id = tpm2_alg_util_strtoalg("sha1");
+    const char *sha1_found_str = tpm2_alg_util_algtostr(ALG_SHA1_VALUE);
+
+    TPM_ALG_ID sha_from_hex_str = tpm2_alg_util_from_optarg("sha");
+    TPM_ALG_ID sha_from_nice_str = tpm2_alg_util_from_optarg(xstr(ALG_SHA_VALUE));
+
+    TPM_ALG_ID sha1_from_hex_str = tpm2_alg_util_from_optarg("sha1");
+    TPM_ALG_ID sha1_from_nice_str = tpm2_alg_util_from_optarg(xstr(ALG_SHA1_VALUE));
+
+    assert_int_equal(ALG_SHA_VALUE, sha_found_id);
+    assert_int_equal(ALG_SHA_VALUE, sha_from_hex_str);
+    assert_int_equal(ALG_SHA_VALUE, sha_from_nice_str);
+
+    assert_int_equal(ALG_SHA1_VALUE, sha1_found_id);
+    assert_int_equal(ALG_SHA_VALUE, sha1_from_hex_str);
+    assert_int_equal(ALG_SHA_VALUE, sha1_from_nice_str);
+
+    bool sha_pass = false;
+    sha_pass = !strcmp(sha_found_str, "sha");
+    sha_pass = !strcmp(sha_found_str, "sha1") || sha_pass;
+
+    assert_true(sha_pass);
+
+    bool sha1_pass = false;
+    sha1_pass = !strcmp(sha1_found_str, "sha");
+    sha1_pass = !strcmp(sha1_found_str, "sha") || sha1_pass;
+
+    assert_true(sha1_pass);
+}
+
+/* make sure no one adds an algorithm to the map that isn't tested */
+static void test_tpm2_alg_util_everything_is_tested(void **state) {
+
+    (void) state;
+
+    TPM_ALG_ID known_algs[] = {
+    ALG_RSA_VALUE,
+    ALG_SHA_VALUE,
+    ALG_SHA1_VALUE,
+    ALG_HMAC_VALUE,
+    ALG_AES_VALUE,
+    ALG_MGF1_VALUE,
+    ALG_KEYEDHASH_VALUE,
+    ALG_XOR_VALUE,
+    ALG_SHA256_VALUE,
+    ALG_SHA384_VALUE,
+    ALG_SHA512_VALUE,
+    ALG_NULL_VALUE,
+    ALG_SM3_256_VALUE,
+    ALG_SM4_VALUE,
+    ALG_RSASSA_VALUE,
+    ALG_RSAES_VALUE,
+    ALG_RSAPSS_VALUE,
+    ALG_OAEP_VALUE,
+    ALG_ECDSA_VALUE,
+    ALG_ECDH_VALUE,
+    ALG_ECDAA_VALUE,
+    ALG_SM2_VALUE,
+    ALG_ECSCHNORR_VALUE,
+    ALG_ECMQV_VALUE,
+    ALG_KDF1_SP800_56A_VALUE,
+    ALG_KDF2_VALUE,
+    ALG_KDF1_SP800_108_VALUE,
+    ALG_ECC_VALUE,
+    ALG_SYMCIPHER_VALUE,
+    ALG_CAMELLIA_VALUE,
+    ALG_SHA3_256_VALUE,
+    ALG_SHA3_384_VALUE,
+    ALG_SHA3_512_VALUE,
+    ALG_CTR_VALUE,
+    ALG_OFB_VALUE,
+    ALG_CBC_VALUE,
+    ALG_CFB_VALUE,
+    ALG_ECB_VALUE };
+
+    find_unk_data userdata = {
+        .ids = known_algs,
+        .len = ARRAY_LEN(known_algs)
+    };
+
+    /*
+     * Go through each element in the list, and check it against
+     * the known algorithm list, if it's present, set the element
+     * in the known list to TPM_ALG_ERROR. At the end, the list
+     * should only contain TPM_ALG_ERROR entries. Anything else
+     * indicates that the map of known algorithms was added to,
+     * but a test was not added.
+     *
+     * Tests that are removed will fail the single_item tests
+     * above since there will not be a match.
+     */
+    tpm2_alg_util_for_each_alg(find_unkown, &userdata);
+
+    size_t i;
+    for (i = 0; i < ARRAY_LEN(known_algs); i++) {
+        assert_int_equal(known_algs[i], TPM_ALG_ERROR);
+    }
+}
+
+int main(int argc, char* argv[]) {
+    (void) argc;
+    (void) argv;
+
+    const struct CMUnitTest tests[] = {
+        single_item_test_get(rsa),
+        cmocka_unit_test(test_tpm2_alg_util_sha_test),
+        single_item_test_get(hmac),
+        single_item_test_get(aes),
+        single_item_test_get(mgf1),
+        single_item_test_get(keyedhash),
+        single_item_test_get(xor),
+        single_item_test_get(sha256),
+        single_item_test_get(sha384),
+        single_item_test_get(sha512),
+        single_item_test_get(null),
+        single_item_test_get(sm3_256),
+        single_item_test_get(sm4),
+        single_item_test_get(rsassa),
+        single_item_test_get(rsaes),
+        single_item_test_get(rsapss),
+        single_item_test_get(oaep),
+        single_item_test_get(ecdsa),
+        single_item_test_get(ecdh),
+        single_item_test_get(ecdaa),
+        single_item_test_get(sm2),
+        single_item_test_get(ecschnorr),
+        single_item_test_get(ecmqv),
+        single_item_test_get(kdf1_sp800_56a),
+        single_item_test_get(kdf2),
+        single_item_test_get(kdf1_sp800_108),
+        single_item_test_get(ecc),
+        single_item_test_get(symcipher),
+        single_item_test_get(camellia),
+        single_item_test_get(sha3_256),
+        single_item_test_get(sha3_384),
+        single_item_test_get(sha3_512),
+        single_item_test_get(ctr),
+        single_item_test_get(ofb),
+        single_item_test_get(cbc),
+        single_item_test_get(cfb),
+        single_item_test_get(ecb),
+        cmocka_unit_test(test_tpm2_alg_util_everything_is_tested)
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tools/tpm2_certify.c
+++ b/tools/tpm2_certify.c
@@ -44,6 +44,7 @@
 #include "main.h"
 #include "options.h"
 #include "password_util.h"
+#include "tpm2_alg_util.h"
 
 typedef struct tpm_certify_ctx tpm_certify_ctx;
 struct tpm_certify_ctx {
@@ -272,8 +273,8 @@ static bool init(int argc, char *argv[], tpm_certify_ctx *ctx) {
             flags.K = 1;
             break;
         case 'g':
-            result = tpm2_util_string_to_uint16(optarg, &ctx->halg);
-            if (!result) {
+            ctx->halg = tpm2_alg_util_from_optarg(optarg);
+            if (ctx->halg == TPM_ALG_ERROR) {
                 LOG_ERR("Could not format algorithm to number, got: \"%s\"",
                         optarg);
                 return false;

--- a/tools/tpm2_create.c
+++ b/tools/tpm2_create.c
@@ -47,6 +47,7 @@
 #include "main.h"
 #include "options.h"
 #include "log.h"
+#include "tpm2_alg_util.h"
 
 TSS2_SYS_CONTEXT *sysContext;
 TPMS_AUTH_COMMAND sessionData = {
@@ -243,8 +244,8 @@ execute_tool (int              argc,
     TPM2B_SENSITIVE_CREATE  inSensitive = TPM2B_EMPTY_INIT;
 
     TPM2B_PUBLIC            inPublic = TPM2B_EMPTY_INIT;
-    TPMI_ALG_PUBLIC type;
-    TPMI_ALG_HASH nameAlg;
+    TPMI_ALG_PUBLIC type = TPM_ALG_SHA1;
+    TPMI_ALG_HASH nameAlg = TPM_ALG_RSA;
     TPMI_DH_OBJECT parentHandle;
     UINT32 objectAttributes = 0;
     char *opuFilePath = NULL;
@@ -321,7 +322,8 @@ execute_tool (int              argc,
             K_flag = 1;
             break;
         case 'g':
-            if(!tpm2_util_string_to_uint16(optarg,&nameAlg))
+            nameAlg = tpm2_alg_util_from_optarg(optarg);
+            if(nameAlg == TPM_ALG_ERROR)
             {
                 showArgError(optarg, argv[0]);
                 returnVal = -4;
@@ -331,7 +333,8 @@ execute_tool (int              argc,
             g_flag = 1;
             break;
         case 'G':
-            if(!tpm2_util_string_to_uint16(optarg,&type))
+            type = tpm2_alg_util_from_optarg(optarg);
+            if(type == TPM_ALG_ERROR)
             {
                 showArgError(optarg, argv[0]);
                 returnVal = -5;

--- a/tools/tpm2_createpolicy.c
+++ b/tools/tpm2_createpolicy.c
@@ -42,6 +42,7 @@
 #include "options.h"
 #include "pcr.h"
 #include "tpm2_policy.h"
+#include "tpm2_alg_util.h"
 
 //Records the type of policy and if one is selected
 typedef struct {
@@ -171,8 +172,10 @@ static bool init(int argc, char *argv[], create_policy_ctx *pctx) {
             pctx->pcr_policy_options.raw_pcrs_file = optarg;
             break;
         case 'g':
-            if (!tpm2_util_string_to_uint16(optarg,
-                    &pctx->common_policy_options.policy_digest_hash_alg)) {
+            pctx->common_policy_options.policy_digest_hash_alg
+                = tpm2_alg_util_from_optarg(optarg);
+            if(pctx->common_policy_options.policy_digest_hash_alg
+                    == TPM_ALG_ERROR) {
                 showArgError(optarg, argv[0]);
                 LOG_ERR("Invalid choice for policy digest hash algorithm\n");
                 return false;

--- a/tools/tpm2_createprimary.c
+++ b/tools/tpm2_createprimary.c
@@ -48,6 +48,7 @@
 #include "main.h"
 #include "options.h"
 #include "password_util.h"
+#include "tpm2_alg_util.h"
 
 TPMS_AUTH_COMMAND sessionData = {
     .sessionHandle = TPM_RS_PW,
@@ -187,8 +188,8 @@ execute_tool (int               argc,
     TPM2B_SENSITIVE_CREATE inSensitive = TPM2B_EMPTY_INIT;
 
     TPM2B_PUBLIC            inPublic = TPM2B_EMPTY_INIT;
-    TPMI_ALG_PUBLIC type;
-    TPMI_ALG_HASH nameAlg;
+    TPMI_ALG_PUBLIC type = TPM_ALG_RSA;
+    TPMI_ALG_HASH nameAlg = TPM_ALG_SHA1;
     TPMI_RH_HIERARCHY hierarchy = TPM_RH_NULL;
 
     setbuf(stdout, NULL);
@@ -262,7 +263,8 @@ execute_tool (int               argc,
             K_flag = 1;
             break;
         case 'g':
-            if(!tpm2_util_string_to_uint16(optarg,&nameAlg))
+            nameAlg = tpm2_alg_util_from_optarg(optarg);
+            if(nameAlg == TPM_ALG_ERROR)
             {
                 showArgError(optarg, argv[0]);
                 returnVal = -4;
@@ -272,7 +274,8 @@ execute_tool (int               argc,
             g_flag = 1;
             break;
         case 'G':
-            if(!tpm2_util_string_to_uint16(optarg,&type))
+            type = tpm2_alg_util_from_optarg(optarg);
+            if(type == TPM_ALG_ERROR)
             {
                 showArgError(optarg, argv[0]);
                 returnVal = -5;

--- a/tools/tpm2_dump_capability.c
+++ b/tools/tpm2_dump_capability.c
@@ -35,6 +35,7 @@
 #include <tcti/tcti_socket.h>
 
 #include "main.h"
+#include "tpm2_alg_util.h"
 #include "tpm2_util.h"
 
 /* convenience macro to convert flags into "set" / "clear" strings */
@@ -447,7 +448,10 @@ void
 dump_algorithm_properties (TPM_ALG_ID       id,
                            TPMA_ALGORITHM   alg_attrs)
 {
-    printf ("TPMA_ALGORITHM for ALG_ID: 0x%x\n", id);
+    const char *id_name = tpm2_alg_util_algtostr(id);
+    id_name = id_name ? id_name : "unknown";
+
+    printf ("TPMA_ALGORITHM for ALG_ID: 0x%x - %s\n", id, id_name);
     printf ("  asymmetric: %s\n", prop_str (alg_attrs.asymmetric));
     printf ("  symmetric:  %s\n", prop_str (alg_attrs.symmetric));
     printf ("  hash:       %s\n", prop_str (alg_attrs.hash));

--- a/tools/tpm2_getmanufec.c
+++ b/tools/tpm2_getmanufec.c
@@ -51,6 +51,7 @@
 #include "main.h"
 #include "options.h"
 #include "tpm_hash.h"
+#include "tpm2_alg_util.h"
 #include "tpm2_util.h"
 
 char *outputFile;
@@ -568,7 +569,8 @@ int execute_tool (int argc, char *argv[], char *envp[], common_opts_t *opts,
                     break;
 
                 case 'g':
-                    if (!tpm2_util_string_to_uint32(optarg, &algorithmType)) {
+                    algorithmType = tpm2_alg_util_from_optarg(optarg);
+                    if (algorithmType == TPM_ALG_ERROR) {
                         printf("\nPlease input the algorithm type in correct format.\n");
                         return return_val;
                     }

--- a/tools/tpm2_getpubak.c
+++ b/tools/tpm2_getpubak.c
@@ -46,6 +46,7 @@
 #include "password_util.h"
 #include "tpm2_util.h"
 #include "tpm_session.h"
+#include "tpm2_alg_util.h"
 
 typedef struct getpubak_context getpubak_context;
 struct getpubak_context {
@@ -61,9 +62,9 @@ struct getpubak_context {
     bool hexPasswd;
     char *outputFile;
     char *aknameFile;
-    UINT32 algorithmType;
-    UINT32 digestAlg;
-    UINT32 signAlg;
+    TPM_ALG_ID algorithmType;
+    TPM_ALG_ID digestAlg;
+    TPM_ALG_ID signAlg;
     TSS2_SYS_CONTEXT *sapi_context;
 };
 
@@ -447,22 +448,22 @@ static bool init(int argc, char *argv[], getpubak_context *ctx) {
             }
             break;
         case 'g':
-            result = tpm2_util_string_to_uint32(optarg, &ctx->algorithmType);
-            if (!result) {
-                LOG_ERR("Could not convert algorithm.");
+            ctx->algorithmType = tpm2_alg_util_from_optarg(optarg);
+            if (ctx->algorithmType == TPM_ALG_ERROR) {
+                LOG_ERR("Could not convert algorithm. got: \"%s\".", optarg);
                 return false;
             }
             break;
         case 'D':
-            result = tpm2_util_string_to_uint32(optarg, &ctx->digestAlg);
-            if (!result) {
+            ctx->digestAlg = tpm2_alg_util_from_optarg(optarg);
+            if (ctx->digestAlg == TPM_ALG_ERROR) {
                 LOG_ERR("Could not convert digest algorithm.");
                 return false;
             }
             break;
         case 's':
-            result = tpm2_util_string_to_uint32(optarg, &ctx->signAlg);
-            if (!result) {
+            ctx->signAlg = tpm2_alg_util_from_optarg(optarg);
+            if (ctx->signAlg == TPM_ALG_ERROR) {
                 LOG_ERR("Could not convert signing algorithm.");
                 return false;
             }

--- a/tools/tpm2_getpubek.c
+++ b/tools/tpm2_getpubek.c
@@ -43,6 +43,7 @@
 #include "main.h"
 #include "password_util.h"
 #include "tpm2_util.h"
+#include "tpm2_alg_util.h"
 
 typedef struct getpubek_context getpubek_context;
 struct getpubek_context {
@@ -54,7 +55,7 @@ struct getpubek_context {
     } passwords;
     char *out_file_path;
     TPM_HANDLE persistent_handle;
-    UINT32 algorithm;
+    TPM_ALG_ID algorithm;
     TSS2_SYS_CONTEXT *sapi_context;
     bool is_session_based_auth;
     TPMI_SH_AUTH_SESSION auth_session_handle;
@@ -315,8 +316,8 @@ static bool init(int argc, char *argv[], char *envp[], getpubek_context *ctx) {
             }
             break;
         case 'g':
-            result = tpm2_util_string_to_uint32(optarg, &ctx->algorithm);
-            if (!result) {
+            ctx->algorithm = tpm2_alg_util_from_optarg(optarg);
+            if (ctx->algorithm == TPM_ALG_ERROR) {
                 LOG_ERR("Could not convert algorithm to value, got: %s",
                         optarg);
                 return false;

--- a/tools/tpm2_hash.c
+++ b/tools/tpm2_hash.c
@@ -42,6 +42,7 @@
 #include "log.h"
 #include "main.h"
 #include "options.h"
+#include "tpm2_alg_util.h"
 #include "tpm2_util.h"
 
 typedef struct tpm_hash_ctx tpm_hash_ctx;
@@ -151,8 +152,8 @@ static bool init(int argc, char *argv[], tpm_hash_ctx *ctx) {
             break;
         case 'g':
             flags++;
-            res = tpm2_util_string_to_uint16(optarg, &ctx->halg);
-            if (!res) {
+            ctx->halg = tpm2_alg_util_from_optarg(optarg);
+            if (ctx->halg == TPM_ALG_ERROR) {
                 showArgError(optarg, argv[0]);
                 return false;
             }

--- a/tools/tpm2_hmac.c
+++ b/tools/tpm2_hmac.c
@@ -44,6 +44,7 @@
 #include "main.h"
 #include "options.h"
 #include "password_util.h"
+#include "tpm2_alg_util.h"
 
 typedef struct tpm_hmac_ctx tpm_hmac_ctx;
 struct tpm_hmac_ctx {
@@ -166,8 +167,8 @@ static bool init(int argc, char *argv[], tpm_hmac_ctx *ctx) {
             flags.P = 1;
             break;
         case 'g':
-            result = tpm2_util_string_to_uint16(optarg, &ctx->algorithm);
-            if (!result) {
+            ctx->algorithm = tpm2_alg_util_from_optarg(optarg);
+            if (ctx->algorithm == TPM_ALG_ERROR) {
                 LOG_ERR("Could not convert algorithm to number, got \"%s\"",
                         optarg);
                 return false;

--- a/tools/tpm2_quote.c
+++ b/tools/tpm2_quote.c
@@ -48,6 +48,7 @@
 #include "log.h"
 #include "main.h"
 #include "pcr.h"
+#include "tpm2_alg_util.h"
 
 typedef struct {
     int size;
@@ -382,7 +383,8 @@ int execute_tool (int argc, char *argv[], char *envp[], common_opts_t *opts,
             l_flag = 1;
             break;
         case 'g':
-            if(!tpm2_util_string_to_uint16(optarg,&pcrSelections.pcrSelections[0].hash))
+            pcrSelections.pcrSelections[0].hash = tpm2_alg_util_from_optarg(optarg);
+            if (pcrSelections.pcrSelections[0].hash == TPM_ALG_ERROR)
             {
                 showArgError(optarg, argv[0]);
                 returnVal = -5;

--- a/tools/tpm2_verifysignature.c
+++ b/tools/tpm2_verifysignature.c
@@ -46,6 +46,7 @@
 #include "options.h"
 #include "tpm2_util.h"
 #include "tpm_hash.h"
+#include "tpm2_alg_util.h"
 
 typedef struct tpm2_verifysig_ctx tpm2_verifysig_ctx;
 struct tpm2_verifysig_ctx {
@@ -242,8 +243,8 @@ static bool handle_options_and_init(int argc, char *argv[], tpm2_verifysig_ctx *
         }
             break;
         case 'g': {
-            bool result = tpm2_util_string_to_uint16(optarg, &ctx->halg);
-            if (!result) {
+            ctx->halg = tpm2_alg_util_from_optarg(optarg);
+            if (ctx->halg == TPM_ALG_ERROR) {
                 LOG_ERR("Unable to convert algorithm, got: \"%s\"", optarg);
                 return false;
             }
@@ -321,7 +322,7 @@ int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
 
     tpm2_verifysig_ctx ctx = {
             .flags = { .all = 0 },
-            .halg = TPM_ALG_SHA256,
+            .halg = TPM_ALG_SHA1,
             .msgHash = TPM2B_TYPE_INIT(TPM2B_DIGEST, buffer),
             .sig_file_path = NULL,
             .msg_file_path = NULL,


### PR DESCRIPTION
This adds support for both PCR lists and algorithm specifiers to use human friendly names rather than hex. I also organized the man pages a little but so the redundant what algorithms are supported are grouped into common files. System tests were updated to use the new nice names.

TODO: Add unit tests.