### PR TITLE
tpm2_getmanufec: handle output more gracefully

### DIFF
--- a/man/tpm2_getmanufec.8.in
+++ b/man/tpm2_getmanufec.8.in
@@ -65,7 +65,8 @@ specifies to readout the EK public without  making it persistent
 specifies that the file specifier from '-f'  is an EK retrieved from offline platform   that needs to be provisioned 
 .TP
 \fB\-E ,\-\-ECcertFile\fR
-specifies the file used to save the  Endorsement Credentials retrieved from   the TPM manufacturer provisioning server 
+Specifies the file used to save the Endorsement Credentials retrieved from the
+TPM manufacturer provisioning server. Defaults to stdout if not specified.
 .TP
 \fB\-S ,\-\-EKserverAddr\fR
 specifies to attempt retrieving the  Endorsement Credentials from the specified   TPM manufacturer provisioning server 
@@ -81,6 +82,10 @@ Optional Input session handle from a policy session for authorization.
 @COMMON_OPTIONS_INCLUDE@
 @TCTI_OPTIONS_INCLUDE@
 .SH ENVIRONMENT\@TCTI_ENVIRONMENT_INCLUDE@
+.SH NOTES
+When the verbose option is specified, additional curl debugging information is
+provided by setting the curl mode verbose, see
+https://curl.haxx.se/libcurl/c/CURLOPT_VERBOSE.html for more information.
 .SH EXAMPLES
 .B tpm2_getmanufec
 .PP

--- a/test/system/test_tpm2_getmanufec.sh
+++ b/test/system/test_tpm2_getmanufec.sh
@@ -50,6 +50,20 @@ if [ $? != 0 ];then
  exit 1
 fi
 
+# Test that stdoutput is the same
+tpm2_getmanufec -g rsa -O -N -U -f test_ek.pub -S https://ekop.intel.com/ekcertservice/ > ECcert2.bin
+if [ $? != 0 ]; then
+ echo "tpm2_getmanufec to stdout command failed, please check the environment or parameters!"
+ exit 1
+fi
+
+# stdout file should match -E file.
+cmp ECcert.bin ECcert2.bin
+if [ $? != 0 ]; then
+ echo "Files produced by tpm2_getmanufec -E and stdout differ, expected to be the same!"
+ exit 1
+fi
+
 if [ $(md5sum ECcert.bin| awk '{ print $1 }') != "56af9eb8a271bbf7ac41b780acd91ff5" ]; then
  echo "Failed: retrieving endorsement certificate"
  exit 1


### PR DESCRIPTION
Currently, the -E option will fail when -E is not specified:
$ tpm2_getmanufec -g 0x01 -O -N -U -f test_ek.pub -S https://ekop.intel.com/ekcertservice/
...
ERROR: Could not open file for writing: "(null)"

Make -E option, optional by making the default stdout. This requires
modifying the tool to stop outputing other information to sdout,
which is currently unused output in the test suite.

Make the information only output when verbose is enabled, this
includes curl verbose information.

Update errors and warnings to go to stderr.

Fixes: 361

Signed-off-by: William Roberts <william.c.roberts@intel.com>