### PR TITLE
NV Attribute friendly name output

### DIFF
--- a/lib/tpm2_nv_util.c
+++ b/lib/tpm2_nv_util.c
@@ -210,7 +210,7 @@ static bool nt(TPMA_NV *nv, char *arg) {
  * This table is in bitfield order, thus the index of a bit set in a TPMA_NV
  * can be used to lookup the name.
  *
- * if not the logic in tpm2_nv_util_attrs_to_val would need to change!
+ * if not the logic in tpm2_nv_util_strtoattr would need to change!
  */
 static dispatch_table dtable[] = {       // Bit Index
     dispatch_no_arg_add(ppwrite),        //  0
@@ -305,7 +305,7 @@ static dispatch_error handle_dispatch(dispatch_table *d, char *token,
     return result ? dispatch_ok : dispatch_err;
 }
 
-bool tpm2_nv_util_attrs_to_val(char *attribute_list, TPMA_NV *nvattrs) {
+bool tpm2_nv_util_strtoattr(char *attribute_list, TPMA_NV *nvattrs) {
 
     char *token;
     char *save;

--- a/lib/tpm2_nv_util.h
+++ b/lib/tpm2_nv_util.h
@@ -22,6 +22,15 @@
 bool tpm2_nv_util_attrs_to_val(char *attribute_list, TPMA_NV *nvattrs);
 
 /**
+ * Converts a TPMA_NV structure to a friendly name style string.
+ * @param nvattrs
+ *  The nvattrs to convert to nice name.
+ * @return A string allocated with calloc(), callers shall use
+ * free() to free it. The string is a null terminated text representation
+ * of the TPMA_NV attributes.
+ */
+char *tpm2_nv_util_attrtostr(TPMA_NV nvattrs);
+/**
  * Reads the public portion of a Non-Volatile (nv) index.
  * @param sapi_context
  *  The system API context.

--- a/lib/tpm2_nv_util.h
+++ b/lib/tpm2_nv_util.h
@@ -19,7 +19,7 @@
  * @return
  *  true on success, false on error.
  */
-bool tpm2_nv_util_attrs_to_val(char *attribute_list, TPMA_NV *nvattrs);
+bool tpm2_nv_util_strtoattr(char *attribute_list, TPMA_NV *nvattrs);
 
 /**
  * Converts a TPMA_NV structure to a friendly name style string.

--- a/lib/tpm2_policy.c
+++ b/lib/tpm2_policy.c
@@ -37,15 +37,13 @@ static bool evaluate_populate_pcr_digests(TPML_PCR_SELECTION pcr_selections,
     unsigned expected_pcr_input_file_size=0;
     //loop counters
     unsigned i, j, k, dgst_cnt=0;
-    const uint8_t bits_per_nibble[] = {0,1,1,2,1,2,2,3,1,2,2,3,2,3,3,4};
 
     //Iterating the number of pcr banks selected
     for (i=0; i < pcr_selections.count; i++) {
         //Looping to check total pcr select bits in the pcr-select-octets for a bank
         for (j=0; j < pcr_selections.pcrSelections[i].sizeofSelect; j++) {
             group_val = pcr_selections.pcrSelections[i].pcrSelect[j];
-            total_indices_for_this_alg += bits_per_nibble[group_val & 0x0f];
-            total_indices_for_this_alg += bits_per_nibble[group_val >> 4];
+            total_indices_for_this_alg += tpm2_util_pop_count(group_val);
         }
 
         //digest size returned per the hashAlg type

--- a/lib/tpm2_util.c
+++ b/lib/tpm2_util.c
@@ -194,3 +194,20 @@ UINT32 tpm2_util_ntoh_32(UINT32 data) {
 UINT64 tpm2_util_ntoh_64(UINT64 data) {
     return tpm2_util_hton_64(data);
 }
+
+UINT32 tpm2_util_pop_count(UINT32 data) {
+
+    static const UINT8 bits_per_nibble[] =
+        {0,1,1,2,1,2,2,3,1,2,2,3,2,3,3,4};
+
+    UINT8 count = 0;
+    UINT8 *d = (UINT8 *)&data;
+
+    size_t i;
+    for (i=0; i < sizeof(data); i++) {
+        count += bits_per_nibble[d[i] & 0x0f];
+        count += bits_per_nibble[d[i] >> 4];
+    }
+
+    return count;
+}

--- a/lib/tpm2_util.h
+++ b/lib/tpm2_util.h
@@ -161,4 +161,13 @@ UINT32 tpm2_util_ntoh_32(UINT32 data);
  */
 UINT64 tpm2_util_ntoh_64(UINT64 data);
 
+/**
+ * Counts the number of set bits aka a population count.
+ * @param data
+ *  The data to count set bits in.
+ * @return
+ *  The number of set bits or population count.
+ */
+UINT32 tpm2_util_pop_count(UINT32 data);
+
 #endif /* STRING_BYTES_H */

--- a/test/unit/test_string_bytes.c
+++ b/test/unit/test_string_bytes.c
@@ -45,6 +45,20 @@ static void test_is_big_endian(void **state) {
     assert_true(test_host_is_big_endian == host_is_big_endian);
 }
 
+static void test_popcount(void **state) {
+
+    (void) state;
+
+    UINT32 count = tpm2_util_pop_count(0x4453E424);
+    assert_int_equal(12, count);
+
+    count = tpm2_util_pop_count(0);
+    assert_int_equal(0, count);
+
+    count = tpm2_util_pop_count(~0);
+    assert_int_equal(32, count);
+}
+
 #define TEST_ENDIAN_CONVERT(size, value, expected) \
     static void test_convert_##size(void **state) { \
     \
@@ -102,6 +116,7 @@ int main(int argc, char* argv[]) {
         cmocka_unit_test(test_ntoh_16),
         cmocka_unit_test(test_ntoh_32),
         cmocka_unit_test(test_ntoh_64),
+        cmocka_unit_test(test_popcount)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/test/unit/test_tpm2_nv_util.c
+++ b/test/unit/test_tpm2_nv_util.c
@@ -34,14 +34,8 @@
 
 #include "tpm2_nv_util.h"
 
-/*
- assert_true(nvattrs.x); \
-    \
-        assert_true(nvattrs.val = TPMA_NV_##x); \
-*/
-
 #define single_test_get(set) \
-    test_tpm2_nv_util_attrs_to_val_##set
+    cmocka_unit_test(test_tpm2_nv_util_attrs_to_val_##set)
 
 #define single_item_test(argstr, set) \
     static void test_tpm2_nv_util_attrs_to_val_##set(void **state) { \
@@ -166,40 +160,156 @@ static void test_tpm2_nv_util_attrs_to_val_token_unknown(void **state) {
     assert_false(res);
 }
 
-//        dispatch_arg_add(nt),
+#define test_attrtostr(value, expected) \
+    static void test_tpm2_nv_util_attrtostr_##value(void **state) { \
+    \
+        (void) state; \
+    \
+        TPMA_NV attrs = { .val = value }; \
+        char *str = tpm2_nv_util_attrtostr(attrs); \
+        assert_string_equal(str, expected); \
+    \
+        free(str); \
+    }
+
+#define test_attrtostr_get(value) \
+		cmocka_unit_test(test_tpm2_nv_util_attrtostr_##value)
+
+test_attrtostr(0, "<none>");
+test_attrtostr(TPMA_NV_TPMA_NV_PPWRITE, "ppwrite")
+test_attrtostr(TPMA_NV_TPMA_NV_OWNERWRITE, "ownerwrite")
+test_attrtostr(TPMA_NV_TPMA_NV_AUTHWRITE, "authwrite")
+test_attrtostr(TPMA_NV_TPMA_NV_POLICYWRITE, "policywrite")
+test_attrtostr(TPMA_NV_TPMA_NV_POLICY_DELETE, "policydelete")
+test_attrtostr(TPMA_NV_TPMA_NV_WRITELOCKED, "writelocked")
+test_attrtostr(TPMA_NV_TPMA_NV_WRITEALL, "writeall")
+test_attrtostr(TPMA_NV_TPMA_NV_WRITEDEFINE, "writedefine")
+test_attrtostr(TPMA_NV_TPMA_NV_WRITE_STCLEAR, "write_stclear")
+test_attrtostr(TPMA_NV_TPMA_NV_GLOBALLOCK, "globallock")
+test_attrtostr(TPMA_NV_TPMA_NV_PPREAD, "ppread")
+test_attrtostr(TPMA_NV_TPMA_NV_OWNERREAD, "ownerread")
+test_attrtostr(TPMA_NV_TPMA_NV_AUTHREAD, "authread")
+test_attrtostr(TPMA_NV_TPMA_NV_POLICYREAD, "policyread")
+test_attrtostr(TPMA_NV_TPMA_NV_NO_DA, "no_da")
+test_attrtostr(TPMA_NV_TPMA_NV_ORDERLY, "orderly")
+test_attrtostr(TPMA_NV_TPMA_NV_CLEAR_STCLEAR, "clear_stclear")
+test_attrtostr(TPMA_NV_TPMA_NV_READLOCKED, "readlocked")
+test_attrtostr(TPMA_NV_TPMA_NV_WRITTEN, "written")
+test_attrtostr(TPMA_NV_TPMA_NV_PLATFORMCREATE, "platformcreate")
+test_attrtostr(TPMA_NV_TPMA_NV_READ_STCLEAR, "read_stclear")
+
+test_attrtostr(0x100, "<reserved(8)>") //bit 8 - reserved
+test_attrtostr(0x200, "<reserved(9)>") //bit 9 - reserved
+
+test_attrtostr(0x100000, "<reserved(20)>")  //bit 20 - reserved
+test_attrtostr(0x200000, "<reserved(21)>")  //bit 21 - reserved
+test_attrtostr(0x400000, "<reserved(22)>")  //bit 22 - reserved
+test_attrtostr(0x800000, "<reserved(23)>")  //bit 23- reserved
+test_attrtostr(0x1000000, "<reserved(24)>") //bit 24- reserved
+
+test_attrtostr(0x30, "nt=0x3") //bit 24- reserved
+test_attrtostr(0x90, "nt=0x9") //bit 24- reserved
+
+#define ALL_FIELDS \
+        "ppwrite|ownerwrite|authwrite|policywrite|nt=0xF|<reserved(8)>"  \
+        "|<reserved(9)>|policydelete|writelocked|writeall|writedefine"   \
+        "|write_stclear|globallock|ppread|ownerread|authread|policyread" \
+        "|<reserved(20)>|<reserved(21)>|<reserved(22)>|<reserved(23)>"   \
+        "|<reserved(24)>|no_da|orderly|clear_stclear|readlocked|written" \
+        "|platformcreate|read_stclear"
+
+test_attrtostr(0xFFFFFFFF, ALL_FIELDS);
+
+#define test_attrtostr_compound(id, value, expected) \
+    static void test_tpm2_nv_util_attrtostr_##id(void **state) { \
+    \
+        (void) state; \
+    \
+        TPMA_NV attrs = { .val = value }; \
+        char *str = tpm2_nv_util_attrtostr(attrs); \
+        assert_string_equal(str, expected); \
+    \
+        free(str); \
+    }
+
+test_attrtostr_compound(stclear_ppwrite,
+        TPMA_NV_TPMA_NV_WRITE_STCLEAR|TPMA_NV_TPMA_NV_PPWRITE,
+        "ppwrite|write_stclear")
+test_attrtostr_compound(stclear_ppwrite_0x30,
+        TPMA_NV_TPMA_NV_WRITE_STCLEAR|TPMA_NV_TPMA_NV_PPWRITE|0x30,
+        "ppwrite|nt=0x3|write_stclear")
+test_attrtostr_compound(platformcreate_owneread_nt_0x90_0x20000,
+        TPMA_NV_TPMA_NV_PLATFORMCREATE|TPMA_NV_TPMA_NV_AUTHWRITE|0x90|0x200000,
+        "authwrite|nt=0x9|<reserved(21)>|platformcreate")
 
 int main(int argc, char* argv[]) {
     (void) argc;
     (void) argv;
 
-    const struct CMUnitTest tests[] = { cmocka_unit_test(
-            single_test_get(TPMA_NV_AUTHREAD)), cmocka_unit_test(
-            single_test_get(TPMA_NV_AUTHWRITE)), cmocka_unit_test(
-            single_test_get(TPMA_NV_CLEAR_STCLEAR)), cmocka_unit_test(
-            single_test_get(TPMA_NV_GLOBALLOCK)), cmocka_unit_test(
-            single_test_get(TPMA_NV_NO_DA)), cmocka_unit_test(
-            single_test_get(TPMA_NV_ORDERLY)), cmocka_unit_test(
-            single_test_get(TPMA_NV_OWNERREAD)), cmocka_unit_test(
-            single_test_get(TPMA_NV_OWNERWRITE)), cmocka_unit_test(
-            single_test_get(TPMA_NV_PLATFORMCREATE)), cmocka_unit_test(
-            single_test_get(TPMA_NV_POLICYREAD)), cmocka_unit_test(
-            single_test_get(TPMA_NV_POLICYWRITE)), cmocka_unit_test(
-            single_test_get(TPMA_NV_POLICY_DELETE)), cmocka_unit_test(
-            single_test_get(TPMA_NV_PPREAD)), cmocka_unit_test(
-            single_test_get(TPMA_NV_PPWRITE)), cmocka_unit_test(
-            single_test_get(TPMA_NV_READLOCKED)), cmocka_unit_test(
-            single_test_get(TPMA_NV_READ_STCLEAR)), cmocka_unit_test(
-            single_test_get(TPMA_NV_WRITEALL)), cmocka_unit_test(
-            single_test_get(TPMA_NV_WRITEDEFINE)), cmocka_unit_test(
-            single_test_get(TPMA_NV_WRITELOCKED)), cmocka_unit_test(
-            single_test_get(TPMA_NV_WRITE_STCLEAR)), cmocka_unit_test(
-            single_test_get(TPMA_NV_WRITTEN)), cmocka_unit_test(
-            test_tpm2_nv_util_attrs_to_val_nt_good), cmocka_unit_test(
-            test_tpm2_nv_util_attrs_to_val_nt_bad), cmocka_unit_test(
-            test_tpm2_nv_util_attrs_to_val_nt_malformed), cmocka_unit_test(
-            test_tpm2_nv_util_attrs_to_val_multiple_good), cmocka_unit_test(
-            test_tpm2_nv_util_attrs_to_val_option_no_option), cmocka_unit_test(
-            test_tpm2_nv_util_attrs_to_val_token_unknown), };
+    const struct CMUnitTest tests[] = {
+            single_test_get(TPMA_NV_AUTHREAD),
+            single_test_get(TPMA_NV_AUTHWRITE),
+            single_test_get(TPMA_NV_CLEAR_STCLEAR),
+            single_test_get(TPMA_NV_GLOBALLOCK),
+            single_test_get(TPMA_NV_NO_DA),
+            single_test_get(TPMA_NV_ORDERLY),
+            single_test_get(TPMA_NV_OWNERREAD),
+            single_test_get(TPMA_NV_OWNERWRITE),
+            single_test_get(TPMA_NV_PLATFORMCREATE),
+            single_test_get(TPMA_NV_POLICYREAD),
+            single_test_get(TPMA_NV_POLICYWRITE),
+            single_test_get(TPMA_NV_POLICY_DELETE),
+            single_test_get(TPMA_NV_PPREAD),
+            single_test_get(TPMA_NV_PPWRITE),
+            single_test_get(TPMA_NV_READLOCKED),
+            single_test_get(TPMA_NV_READ_STCLEAR),
+            single_test_get(TPMA_NV_WRITEALL),
+            single_test_get(TPMA_NV_WRITEDEFINE),
+            single_test_get(TPMA_NV_WRITELOCKED),
+            single_test_get(TPMA_NV_WRITE_STCLEAR),
+            single_test_get(TPMA_NV_WRITTEN),
+            cmocka_unit_test(test_tpm2_nv_util_attrs_to_val_nt_good),
+            cmocka_unit_test(test_tpm2_nv_util_attrs_to_val_nt_bad),
+            cmocka_unit_test(test_tpm2_nv_util_attrs_to_val_nt_malformed),
+            cmocka_unit_test(test_tpm2_nv_util_attrs_to_val_multiple_good),
+            cmocka_unit_test(test_tpm2_nv_util_attrs_to_val_option_no_option),
+            cmocka_unit_test(test_tpm2_nv_util_attrs_to_val_token_unknown),
+            test_attrtostr_get(TPMA_NV_TPMA_NV_PPWRITE),
+            test_attrtostr_get(TPMA_NV_TPMA_NV_OWNERWRITE),
+            test_attrtostr_get(TPMA_NV_TPMA_NV_AUTHWRITE),
+            test_attrtostr_get(TPMA_NV_TPMA_NV_POLICYWRITE),
+            test_attrtostr_get(TPMA_NV_TPMA_NV_POLICY_DELETE),
+            test_attrtostr_get(TPMA_NV_TPMA_NV_WRITELOCKED),
+            test_attrtostr_get(TPMA_NV_TPMA_NV_WRITEALL),
+            test_attrtostr_get(TPMA_NV_TPMA_NV_WRITEDEFINE),
+            test_attrtostr_get(TPMA_NV_TPMA_NV_WRITE_STCLEAR),
+            test_attrtostr_get(TPMA_NV_TPMA_NV_GLOBALLOCK),
+            test_attrtostr_get(TPMA_NV_TPMA_NV_PPREAD),
+            test_attrtostr_get(TPMA_NV_TPMA_NV_OWNERREAD),
+            test_attrtostr_get(TPMA_NV_TPMA_NV_AUTHREAD),
+            test_attrtostr_get(TPMA_NV_TPMA_NV_POLICYREAD),
+            test_attrtostr_get(TPMA_NV_TPMA_NV_NO_DA),
+            test_attrtostr_get(TPMA_NV_TPMA_NV_ORDERLY),
+            test_attrtostr_get(TPMA_NV_TPMA_NV_CLEAR_STCLEAR),
+            test_attrtostr_get(TPMA_NV_TPMA_NV_READLOCKED),
+            test_attrtostr_get(TPMA_NV_TPMA_NV_WRITTEN),
+            test_attrtostr_get(TPMA_NV_TPMA_NV_PLATFORMCREATE),
+            test_attrtostr_get(TPMA_NV_TPMA_NV_READ_STCLEAR),
+            test_attrtostr_get(0),
+            test_attrtostr_get(0xFFFFFFFF),
+            test_attrtostr_get(0x100),     // bit 8 - reserved
+            test_attrtostr_get(0x200),     // bit 9 - reserved
+            test_attrtostr_get(0x100000),  //bit 20 - reserved
+            test_attrtostr_get(0x200000),  //bit 21 - reserved
+            test_attrtostr_get(0x400000),  //bit 22 - reserved
+            test_attrtostr_get(0x800000),  //bit 23- reserved
+            test_attrtostr_get(0x1000000), //bit 24- reserved
+            test_attrtostr_get(0x30), //nt=0x3
+            test_attrtostr_get(0x90), //nt=0x9
+            test_attrtostr_get(stclear_ppwrite),
+            test_attrtostr_get(stclear_ppwrite_0x30),
+            test_attrtostr_get(platformcreate_owneread_nt_0x90_0x20000)
+    };
 
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/test/unit/test_tpm2_nv_util.c
+++ b/test/unit/test_tpm2_nv_util.c
@@ -35,10 +35,10 @@
 #include "tpm2_nv_util.h"
 
 #define single_test_get(set) \
-    cmocka_unit_test(test_tpm2_nv_util_attrs_to_val_##set)
+    cmocka_unit_test(test_tpm2_nv_util_strtoattr_##set)
 
 #define single_item_test(argstr, set) \
-    static void test_tpm2_nv_util_attrs_to_val_##set(void **state) { \
+    static void test_tpm2_nv_util_strtoattr_##set(void **state) { \
         \
         (void)state; \
     \
@@ -47,7 +47,7 @@
         }; \
         /* make mutable strings for strtok_r */ \
         char arg[] = argstr; \
-        bool res = tpm2_nv_util_attrs_to_val(arg, &nvattrs); \
+        bool res = tpm2_nv_util_strtoattr(arg, &nvattrs); \
         assert_true(res); \
         assert_true(nvattrs.set); \
         assert_true(nvattrs.val == TPMA_NV_##set); \
@@ -75,88 +75,88 @@ single_item_test("writelocked", TPMA_NV_WRITELOCKED);
 single_item_test("write_stclear", TPMA_NV_WRITE_STCLEAR);
 single_item_test("written", TPMA_NV_WRITTEN);
 
-static void test_tpm2_nv_util_attrs_to_val_nt_good(void **state) {
+static void test_tpm2_nv_util_strtoattr_nt_good(void **state) {
     (void) state;
 
     TPMA_NV nvattrs = { .val = 0, };
 
     char arg[] = "nt=0x1";
-    bool res = tpm2_nv_util_attrs_to_val(arg, &nvattrs);
+    bool res = tpm2_nv_util_strtoattr(arg, &nvattrs);
     assert_true(res);
     assert_true(nvattrs.TPM_NT == 0x1);
 }
 
-static void test_tpm2_nv_util_attrs_to_val_nt_bad(void **state) {
+static void test_tpm2_nv_util_strtoattr_nt_bad(void **state) {
     (void) state;
 
     TPMA_NV nvattrs = { .val = 0, };
 
     char arg[] = "nt=16";
-    bool res = tpm2_nv_util_attrs_to_val(arg, &nvattrs);
+    bool res = tpm2_nv_util_strtoattr(arg, &nvattrs);
     assert_false(res);
 }
 
-static void test_tpm2_nv_util_attrs_to_val_nt_malformed(void **state) {
+static void test_tpm2_nv_util_strtoattr_nt_malformed(void **state) {
     (void) state;
 
     TPMA_NV nvattrs = { .val = 0, };
 
     char arg[] = "nt=";
-    bool res = tpm2_nv_util_attrs_to_val(arg, &nvattrs);
+    bool res = tpm2_nv_util_strtoattr(arg, &nvattrs);
     assert_false(res);
 
     char arg1[] = "nt";
-    res = tpm2_nv_util_attrs_to_val(arg1, &nvattrs);
+    res = tpm2_nv_util_strtoattr(arg1, &nvattrs);
     assert_false(res);
 }
 
-static void test_tpm2_nv_util_attrs_to_val_option_no_option(void **state) {
+static void test_tpm2_nv_util_strtoattr_option_no_option(void **state) {
     (void) state;
 
     TPMA_NV nvattrs = { .val = 0, };
 
     char arg[] = "authread=";
-    bool res = tpm2_nv_util_attrs_to_val(arg, &nvattrs);
+    bool res = tpm2_nv_util_strtoattr(arg, &nvattrs);
     assert_false(res);
 
     char arg1[] = "authread=0x1";
-    res = tpm2_nv_util_attrs_to_val(arg1, &nvattrs);
+    res = tpm2_nv_util_strtoattr(arg1, &nvattrs);
     assert_false(res);
 }
 
-static void test_tpm2_nv_util_attrs_to_val_multiple_good(void **state) {
+static void test_tpm2_nv_util_strtoattr_multiple_good(void **state) {
     (void) state;
 
     TPMA_NV nvattrs = { .val = 0, };
 
     char arg[] = "authread|authwrite|nt=0x4";
-    bool res = tpm2_nv_util_attrs_to_val(arg, &nvattrs);
+    bool res = tpm2_nv_util_strtoattr(arg, &nvattrs);
     assert_true(res);
     assert_true(nvattrs.TPM_NT == 0x4);
     assert_true(nvattrs.TPMA_NV_AUTHREAD);
     assert_true(nvattrs.TPMA_NV_AUTHWRITE);
 }
 
-static void test_tpm2_nv_util_attrs_to_val_token_unknown(void **state) {
+static void test_tpm2_nv_util_strtoattr_token_unknown(void **state) {
     (void) state;
 
     TPMA_NV nvattrs = { .val = 0, };
 
     char arg[] = "authread|authfoo|nt=0x4";
-    bool res = tpm2_nv_util_attrs_to_val(arg, &nvattrs);
+    bool res = tpm2_nv_util_strtoattr(arg, &nvattrs);
     assert_false(res);
 
     char arg1[] = "foo";
-    res = tpm2_nv_util_attrs_to_val(arg1, &nvattrs);
+    res = tpm2_nv_util_strtoattr(arg1, &nvattrs);
     assert_false(res);
 
     char arg2[] = "foo=";
-    res = tpm2_nv_util_attrs_to_val(arg2, &nvattrs);
+    res = tpm2_nv_util_strtoattr(arg2, &nvattrs);
     assert_false(res);
 
     /* should be interprested as the whole thing, no = */
     char arg3[] = "nt:0x4";
-    res = tpm2_nv_util_attrs_to_val(arg3, &nvattrs);
+    res = tpm2_nv_util_strtoattr(arg3, &nvattrs);
     assert_false(res);
 }
 
@@ -268,12 +268,12 @@ int main(int argc, char* argv[]) {
             single_test_get(TPMA_NV_WRITELOCKED),
             single_test_get(TPMA_NV_WRITE_STCLEAR),
             single_test_get(TPMA_NV_WRITTEN),
-            cmocka_unit_test(test_tpm2_nv_util_attrs_to_val_nt_good),
-            cmocka_unit_test(test_tpm2_nv_util_attrs_to_val_nt_bad),
-            cmocka_unit_test(test_tpm2_nv_util_attrs_to_val_nt_malformed),
-            cmocka_unit_test(test_tpm2_nv_util_attrs_to_val_multiple_good),
-            cmocka_unit_test(test_tpm2_nv_util_attrs_to_val_option_no_option),
-            cmocka_unit_test(test_tpm2_nv_util_attrs_to_val_token_unknown),
+            cmocka_unit_test(test_tpm2_nv_util_strtoattr_nt_good),
+            cmocka_unit_test(test_tpm2_nv_util_strtoattr_nt_bad),
+            cmocka_unit_test(test_tpm2_nv_util_strtoattr_nt_malformed),
+            cmocka_unit_test(test_tpm2_nv_util_strtoattr_multiple_good),
+            cmocka_unit_test(test_tpm2_nv_util_strtoattr_option_no_option),
+            cmocka_unit_test(test_tpm2_nv_util_strtoattr_token_unknown),
             test_attrtostr_get(TPMA_NV_TPMA_NV_PPWRITE),
             test_attrtostr_get(TPMA_NV_TPMA_NV_OWNERWRITE),
             test_attrtostr_get(TPMA_NV_TPMA_NV_AUTHWRITE),

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -207,7 +207,7 @@ static bool init(int argc, char* argv[], tpm_nvdefine_ctx *ctx) {
         case 't':
             result = tpm2_util_string_to_uint32(optarg, &ctx->nvAttribute.val);
             if (!result) {
-                result = tpm2_nv_util_attrs_to_val(optarg, &ctx->nvAttribute);
+                result = tpm2_nv_util_strtoattr(optarg, &ctx->nvAttribute);
                 if (!result) {
                     LOG_ERR("Could not convert NV attribute to number or keyword, got: \"%s\"",
                         optarg);

--- a/tools/tpm2_nvdefine.c
+++ b/tools/tpm2_nvdefine.c
@@ -56,7 +56,6 @@ struct tpm_nvdefine_ctx {
     TPM2B_AUTH indexPasswd;
     bool hexPasswd;
     TSS2_SYS_CONTEXT *sapi_context;
-    bool policy_file_flag;
     char *policy_file;
     bool is_auth_session;
     TPMI_SH_AUTH_SESSION auth_session_handle;
@@ -108,7 +107,7 @@ static int nv_space_define(tpm_nvdefine_ctx *ctx) {
     // Now set the attributes.
     public_info.t.nvPublic.attributes.val = ctx->nvAttribute.val;
 
-    if (ctx->policy_file_flag) {
+    if (ctx->policy_file) {
         public_info.t.nvPublic.authPolicy.t.size  = BUFFER_SIZE(TPM2B_DIGEST, buffer);
         if(!files_load_bytes_from_file(ctx->policy_file, public_info.t.nvPublic.authPolicy.t.buffer, &public_info.t.nvPublic.authPolicy.t.size )) {
             return false;
@@ -228,7 +227,6 @@ static bool init(int argc, char* argv[], tpm_nvdefine_ctx *ctx) {
             break;
         case 'L':
             ctx->policy_file = optarg;
-            ctx->policy_file_flag = true;
             break;
         case 'S':
              if (!tpm2_util_string_to_uint32(optarg, &ctx->auth_session_handle)) {
@@ -268,7 +266,7 @@ int execute_tool(int argc, char *argv[], char *envp[], common_opts_t *opts,
             .indexPasswd = TPM2B_EMPTY_INIT,
             .hexPasswd = false,
             .sapi_context = sapi_context,
-            .policy_file_flag = false,
+            .policy_file = NULL,
             .is_auth_session = false
         };
 

--- a/tools/tpm2_nvlist.c
+++ b/tools/tpm2_nvlist.c
@@ -51,7 +51,7 @@ static void print_nv_public(TPM2B_NV_PUBLIC *nv_public) {
     printf("  {\n");
     printf("\tHash algorithm(nameAlg):%d\n ", nv_public->t.nvPublic.nameAlg);
     printf("\tattributes: %s(0x%x)\n ", attrs,
-            nv_public->t.nvPublic.attributes.val);
+            tpm2_util_ntoh_32(nv_public->t.nvPublic.attributes.val));
     printf("\tThe size of the data area(dataSize):%d\n ",
             nv_public->t.nvPublic.dataSize);
     printf("\tAuthorization Policy for R/W/D: ");

--- a/tools/tpm2_nvlist.c
+++ b/tools/tpm2_nvlist.c
@@ -50,7 +50,7 @@ static void print_nv_public(TPM2B_NV_PUBLIC *nv_public) {
 
     printf("  {\n");
     printf("\tHash algorithm(nameAlg):%d\n ", nv_public->t.nvPublic.nameAlg);
-    printf("\tattributes: %s(0x%x)\n ", attrs,
+    printf("\tattributes: %s(0x%X)\n ", attrs,
             tpm2_util_ntoh_32(nv_public->t.nvPublic.attributes.val));
     printf("\tThe size of the data area(dataSize):%d\n ",
             nv_public->t.nvPublic.dataSize);

--- a/tools/tpm2_nvlist.c
+++ b/tools/tpm2_nvlist.c
@@ -42,9 +42,15 @@
 #include "options.h"
 
 static void print_nv_public(TPM2B_NV_PUBLIC *nv_public) {
+
+    char *attrs = tpm2_nv_util_attrtostr(nv_public->t.nvPublic.attributes);
+    if (!attrs) {
+        LOG_ERR("Could not convert attributes to string form");
+    }
+
     printf("  {\n");
     printf("\tHash algorithm(nameAlg):%d\n ", nv_public->t.nvPublic.nameAlg);
-    printf("\tThe Index attributes(attributes):0x%x\n ",
+    printf("\tattributes: %s(0x%x)\n ", attrs,
             nv_public->t.nvPublic.attributes.val);
     printf("\tThe size of the data area(dataSize):%d\n ",
             nv_public->t.nvPublic.dataSize);
@@ -54,6 +60,8 @@ static void print_nv_public(TPM2B_NV_PUBLIC *nv_public) {
         printf("%02X", nv_public->t.nvPublic.authPolicy.t.buffer[i] );
     }
     printf("\n  }\n");
+
+    free(attrs);
 }
 
 static bool nv_list(TSS2_SYS_CONTEXT *sapi_context) {


### PR DESCRIPTION
Instead of outputting the raw hex, which sucks for humans, output a nice name formatted nv attribute list. Add numerous tests to the unit testing library and update tpm2_nvlist.

Inspired by #348 

Example:
Old Output:
```
    1 NV indexes defined.
    
      0. NV Index: 0x1500016
      {
        Hash algorithm(nameAlg):11
        The Index attributes(attributes):0xa000a
        The size of the data area(dataSize):32
        Authorization Policy for R/W/D:
      }
```
New Output:
```
    1 NV indexes defined.
    
      0. NV Index: 0x1500016
      {
        Hash algorithm(nameAlg):11
        attributes: ownerwrite|policywrite|ownerread|policyread(0xa000a)
        The size of the data area(dataSize):32
        Authorization Policy for R/W/D:
      }
```